### PR TITLE
docs: fix hosted Proof link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Proof SDK is the open-source editor, collaboration server, provenance model, and agent HTTP bridge that power collaborative documents in Proof.
 
-If you want the hosted product, use [Proof](https://proof.com).
+If you want the hosted product, use [Proof](https://proofeditor.ai).
 
 ## What Is Included
 


### PR DESCRIPTION
Fix the hosted product link in the proof-sdk README so it points to https://proofeditor.ai instead of https://proof.com.