### PR TITLE
Correct hosted product link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Proof SDK is the open-source editor, collaboration server, provenance model, and agent HTTP bridge that power collaborative documents in Proof.
 
-If you want the hosted product, use [Proof](https://proof.com).
+If you want the hosted product, use [Proof](https://proofeditor.ai).
 
 ## What Is Included
 


### PR DESCRIPTION
This pull request updates the `README.md` to reflect the correct link for the hosted product. The link now points to the current `proofeditor.ai` domain instead of the previous `proof.com` domain.

* Updated the hosted product link in `README.md` to use `https://proofeditor.ai` instead of `https://proof.com`.