### PR TITLE
fix: update wordmark link to correct domain

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -3340,7 +3340,7 @@ class ProofEditorImpl implements ProofEditor {
 
     const wordmark = document.createElement('a');
     wordmark.textContent = 'Proof';
-    wordmark.href = 'https://proof.com';
+    wordmark.href = 'https://proofeditor.ai';
     wordmark.target = '_blank';
     wordmark.rel = 'noopener';
     wordmark.style.cssText = 'display:inline-flex;align-items:center;justify-content:center;min-height:44px;min-width:44px;padding:0 8px;border-radius:10px;font-weight:600;color:#333;font-size:13px;letter-spacing:-0.2px;flex-shrink:0;text-decoration:none;';


### PR DESCRIPTION
The wordmark link in the editor nav points to `https://proof.com`, which is not owned by Every. This updates it to `https://proofeditor.ai`.