### PR TITLE
fix: increment revision on updateMarks to preserve CAS invariant

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -1376,7 +1376,7 @@ export function updateMarks(slug: string, marks: Record<string, unknown>): boole
   const now = new Date().toISOString();
   const result = getDb().prepare(`
     UPDATE documents
-    SET marks = ?, updated_at = ?
+    SET marks = ?, updated_at = ?, revision = revision + 1
     WHERE slug = ? AND share_state IN ('ACTIVE', 'PAUSED')
   `).run(JSON.stringify(marks), now, slug);
   if (result.changes > 0) {


### PR DESCRIPTION
## Bug

`updateMarks` in `server/db.ts` updated `marks` and `updated_at` but never incremented `revision`:

```sql
-- before
SET marks = ?, updated_at = ?

-- after
SET marks = ?, updated_at = ?, revision = revision + 1
```

Every other write path (`updateDocumentAtomic`, `updateDocumentAtomicByRevision`) increments `revision`. `updateMarks` did not.

## Impact

The `edit/v2` endpoint uses `baseRevision` as a CAS lock via `updateDocumentAtomicByRevision`. Because marks mutations left `revision` unchanged, an agent could:

1. Read the document at `revision = N`
2. A marks mutation fires — document still at `revision = N`
3. Agent calls `edit/v2` with `baseRevision = N` — CAS check passes on a stale base
4. Agent write silently clobbers the mark anchors

## Fix

Added `revision = revision + 1` to the `updateMarks` SQL in `server/db.ts`, consistent with all other write paths.