### PR TITLE
fix: persist and replay original status code in idempotency layer

### DIFF
--- a/server/agent-routes.ts
+++ b/server/agent-routes.ts
@@ -419,7 +419,7 @@ function maybeReplayIdempotentMutation(
     );
     return { handled: true, idempotencyKey, requestHash };
   }
-  sendMutationResponse(res, 200, existing.response, { route: mutationRoute, slug });
+  sendMutationResponse(res, existing.statusCode ?? 200, existing.response, { route: mutationRoute, slug });
   return { handled: true, idempotencyKey, requestHash };
 }
 
@@ -432,7 +432,7 @@ function storeIdempotentMutationResult(
 ): void {
   if (!replay.idempotencyKey) return;
   if (status < 200 || status >= 300) return;
-  storeIdempotencyResult(slug, routeKey, replay.idempotencyKey, body, replay.requestHash);
+  storeIdempotencyResult(slug, routeKey, replay.idempotencyKey, body, replay.requestHash, { statusCode: status });
 }
 
 function routeRequiresMutation(method: string, path: string): boolean {

--- a/server/db.ts
+++ b/server/db.ts
@@ -1973,14 +1973,14 @@ export function getStoredIdempotencyRecord(
   documentSlug: string,
   route: string,
   idempotencyKey: string,
-): { response: Record<string, unknown>; requestHash: string | null } | null {
+): { response: Record<string, unknown>; requestHash: string | null; statusCode: number } | null {
   const d = getDb();
   const coordinatorRow = d.prepare(`
-    SELECT response_json, request_hash
+    SELECT response_json, request_hash, status_code
     FROM ${MUTATION_IDEMPOTENCY_TABLE}
     WHERE idempotency_key = ? AND document_slug = ? AND route = ?
     LIMIT 1
-  `).get(idempotencyKey, documentSlug, route) as { response_json?: string; request_hash?: string | null } | undefined;
+  `).get(idempotencyKey, documentSlug, route) as { response_json?: string; request_hash?: string | null; status_code?: number | null } | undefined;
   const legacyRow = d.prepare(`
     SELECT response_json, request_hash
     FROM idempotency_keys
@@ -2010,6 +2010,7 @@ export function getStoredIdempotencyRecord(
     return {
       response,
       requestHash: typeof row.request_hash === 'string' ? row.request_hash : null,
+      statusCode: typeof (row as { status_code?: number | null }).status_code === 'number' ? (row as { status_code: number }).status_code : 200,
     };
   } catch {
     return null;


### PR DESCRIPTION
## Bug

The idempotency layer had a `status_code` column in the DB and an `options.statusCode` parameter in `storeIdempotencyResult()`, but the wiring was never completed:

| Location | Problem |
|---|---|
| `storeIdempotentMutationResult()` | Called `storeIdempotencyResult` without passing `statusCode` |
| `getStoredIdempotencyRecord()` | Never read `status_code` from the DB |
| `maybeReplayIdempotentMutation()` | Hardcoded `200` in the replay response |

Result: every idempotency replay returned `200` regardless of the original status — e.g. a `201 Created` became `200 OK` on retry.

## Fix

Threaded `status_code` through all three layers in `server/db.ts` and `server/agent-routes.ts`:

```ts
// storeIdempotentMutationResult — pass status through
storeIdempotencyResult(slug, routeKey, replay.idempotencyKey, body, replay.requestHash, { statusCode: status })

// getStoredIdempotencyRecord — read it back
SELECT response_json, request_hash, status_code FROM mutation_idempotency ...
return { response, requestHash, statusCode }

// maybeReplayIdempotentMutation — use stored value, fallback to 200 for legacy rows
sendMutationResponse(res, stored.statusCode ?? 200, stored.response)
```

Legacy rows without `status_code` fall back to `200` (the column defaults to `200` per the existing migration).