### PR TITLE
fix: serve dist/assets when self-hosting the editor

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -44,6 +44,7 @@ async function main(): Promise<void> {
 
   app.use(express.json({ limit: '10mb' }));
   app.use(express.static(path.join(__dirname, '..', 'public')));
+  app.use(express.static(path.join(__dirname, '..', 'dist')));
 
   app.use((req, res, next) => {
     const originHeader = req.header('origin');


### PR DESCRIPTION
## Problem

When self-hosting the Proof SDK, the editor loads as a blank white page with no UI.

`share-web-routes.ts` correctly reads `dist/index.html` and serves it as the SPA shell for `/d/:slug` routes. However, `server/index.ts` only mounts a static file server for `public/` — not `dist/`.

This means the browser receives the editor HTML, immediately tries to fetch `/assets/editor.js` (and other built assets), gets a 404 for each, and the page stays blank.

## Reproduction

```bash
# Clone, install, build
git clone https://github.com/EveryInc/proof-sdk.git
cd proof-sdk
npm install
npm run build
npm run serve

# Create a doc
curl -X POST http://localhost:4000/documents   -H 'Content-Type: application/json'   -d '{"title": "Test", "markdown": "# Test"}'

# Open the returned /d/<slug> URL in a browser
# Result: blank white page, browser console shows 404s for /assets/editor.js
```

## Fix

Add `dist/` as a static file directory alongside the existing `public/` server in `server/index.ts`:

```diff
  app.use(express.static(path.join(__dirname, '..', 'public')));
+ app.use(express.static(path.join(__dirname, '..', 'dist')));
```

One line. No behaviour change for the API or hosted runtime — only affects the self-hosted editor frontend path.