### PR TITLE
docs: fix hosted Proof link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Proof SDK is the open-source editor, collaboration server, provenance model, and agent HTTP bridge that power collaborative documents in Proof.
 
-If you want the hosted product, use [Proof](https://proof.com).
+If you want the hosted product, use [Proof](https://proofeditor.ai).
 
 ## What Is Included
 


### PR DESCRIPTION
Small docs fix: the README linked to proof.com instead of proofeditor.ai for the hosted product.

- update the hosted product link in README

No code changes.