### PR TITLE
fix: add editV2 types and method to agent-bridge client

### DIFF
--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -203,10 +203,15 @@ export function createAgentBridgeClient(config: AgentBridgeClientConfig) {
       });
     },
     editV2<T = unknown>(slug: string, input: EditV2Input, options: AgentBridgeRequestOptions = {}): Promise<T> {
+      const { idempotencyKey, ...body } = input;
+      const headers: Record<string, string> = { ...(options.headers ?? {}) };
+      if (idempotencyKey) {
+        headers['Idempotency-Key'] = idempotencyKey;
+      }
       return requestJson<T>(config, `${documentBasePath(slug)}/edit/v2`, {
         method: 'POST',
-        body: JSON.stringify(input),
-        ...options,
+        body: JSON.stringify(body),
+        headers,
       });
     },
     rewrite<T = unknown>(slug: string, input: Record<string, unknown>, options: AgentBridgeRequestOptions = {}): Promise<T> {

--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -38,6 +38,21 @@ export interface AgentBridgeCommentInput {
   selector?: Record<string, unknown>;
 }
 
+export type EditV2BlockOp =
+  | { op: 'replace_block'; ref: string; block: { markdown: string } }
+  | { op: 'insert_after'; ref: string; blocks: Array<{ markdown: string }> }
+  | { op: 'insert_before'; ref: string; blocks: Array<{ markdown: string }> }
+  | { op: 'delete_block'; ref: string }
+  | { op: 'replace_range'; fromRef: string; toRef: string; blocks: Array<{ markdown: string }> }
+  | { op: 'find_replace_in_block'; ref: string; find: string; replace: string; occurrence?: 'first' | 'all' };
+
+export interface EditV2Input {
+  by: string;
+  baseRevision: number;
+  operations: EditV2BlockOp[];
+  idempotencyKey?: string;
+}
+
 export interface AgentBridgePresenceInput {
   status: string;
   agentId?: string;
@@ -182,6 +197,13 @@ export function createAgentBridgeClient(config: AgentBridgeClientConfig) {
     },
     addSuggestion<T = unknown>(slug: string, input: AgentBridgeSuggestionInput, options: AgentBridgeRequestOptions = {}): Promise<T> {
       return requestJson<T>(config, buildBridgePath(slug, '/suggestions'), {
+        method: 'POST',
+        body: JSON.stringify(input),
+        ...options,
+      });
+    },
+    editV2<T = unknown>(slug: string, input: EditV2Input, options: AgentBridgeRequestOptions = {}): Promise<T> {
+      return requestJson<T>(config, `${documentBasePath(slug)}/edit/v2`, {
         method: 'POST',
         body: JSON.stringify(input),
         ...options,


### PR DESCRIPTION
## Summary

The `@proof/agent-bridge` client is missing `editV2` support. The issue (#22) reported mismatched field names (`revision`/`ops` vs `baseRevision`/`operations`), but the root cause is that the `editV2` method and types don't exist in the bridge client at all.

This adds:
- `EditV2BlockOp` — discriminated union matching all six server operation types (`replace_block`, `insert_after`, `insert_before`, `delete_block`, `replace_range`, `find_replace_in_block`)
- `EditV2Input` — interface with correct field names (`baseRevision`, `operations`) matching `server/agent-edit-v2.ts`
- `editV2()` method on the bridge client, posting to `/documents/:slug/edit/v2`

## Test plan

- [ ] `createAgentBridgeClient(config).editV2(slug, { by, baseRevision, operations })` sends correct payload
- [ ] Server accepts the request without "baseRevision is required" error
- [ ] TypeScript catches wrong field names at compile time

Closes #22

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)