### PR TITLE
fix: move AbortSignal from API request body to SDK options

### DIFF
--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -289,7 +289,6 @@ export class AgentService {
           system: systemPrompt,
           messages,
           tools: anthropicTools,
-          signal: this.abortController?.signal,
         };
         if (runtimeConfig.thinkingBudgetTokens > 0) {
           request.thinking = {
@@ -297,7 +296,9 @@ export class AgentService {
             budget_tokens: runtimeConfig.thinkingBudgetTokens,
           };
         }
-        result = await this.client!.messages.create(request);
+        result = await this.client!.messages.create(request, {
+          signal: this.abortController?.signal ?? undefined,
+        });
 
         if (this.abortController?.signal.aborted) {
           throw new Error('Agent cancelled by user');


### PR DESCRIPTION
## Summary

`AgentService.runAgentLoop` passes `signal` inside the Anthropic API request body object. The API rejects this with a 400:

```
signal: Extra inputs are not permitted
```

`signal` is a client-side SDK option for request cancellation, not an API parameter. It belongs in the second argument to `client.messages.create()`.

**Before:**
```typescript
const request = { model, messages, tools, signal: this.abortController?.signal };
result = await this.client!.messages.create(request);
```

**After:**
```typescript
const request = { model, messages, tools };
result = await this.client!.messages.create(request, {
  signal: this.abortController?.signal ?? undefined,
});
```

One-line fix. The abort signal still works for cancellation — it's just passed in the right place now.

## Test plan

- [ ] "Ask Proof" agent dialog no longer fails with "Extra inputs are not permitted"
- [ ] Cancelling an in-progress agent request still aborts the API call

Closes #26

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)