### PR TITLE
Fix local dev server: serve dist/ assets and fix WebSocket port

### DIFF
--- a/server/collab.ts
+++ b/server/collab.ts
@@ -10406,6 +10406,12 @@ export async function startCollabRuntimeEmbedded(mainHttpPort: number): Promise<
       },
     } as unknown);
 
+    // Signal embedded mode so resolveRequestScopedCollabWsBase keeps the
+    // main HTTP port instead of adding +1 for a standalone collab port.
+    if (!process.env.COLLAB_EMBEDDED_WS) {
+      process.env.COLLAB_EMBEDDED_WS = '1';
+    }
+
     runtime = {
       enabled: true,
       wsUrlBase: wsUrlBase.replace(/\/+$/, ''),

--- a/server/index.ts
+++ b/server/index.ts
@@ -44,6 +44,7 @@ async function main(): Promise<void> {
 
   app.use(express.json({ limit: '10mb' }));
   app.use(express.static(path.join(__dirname, '..', 'public')));
+  app.use(express.static(path.join(__dirname, '..', 'dist')));
 
   app.use((req, res, next) => {
     const originHeader = req.header('origin');


### PR DESCRIPTION
## Summary

Two issues prevented `npm run build && npm run serve` from working out of the box for local development:

- **Missing static file serving for `dist/`**: The Express server only served files from `public/` but the built `editor.js` bundle lives in `dist/assets/`, returning 404 and showing a white screen.
- **WebSocket connecting to wrong port**: `startCollabRuntimeEmbedded` correctly sets `wsUrlBase` to `ws://localhost:4000/ws`, but `resolveRequestScopedCollabWsBase` didn't know the runtime was embedded. Without the `COLLAB_EMBEDDED_WS` flag, it computed port+1 (4001) for the collab WebSocket URL, causing connection refused errors and a perpetual "Connecting" state.

## Changes

- `server/index.ts`: Add `express.static` for the `dist/` directory so built assets are served
- `server/collab.ts`: Set `COLLAB_EMBEDDED_WS=1` in `startCollabRuntimeEmbedded` so the request-scoped URL resolver uses the correct port

## Test plan

- [ ] `npm install && npm run build && npm run serve`
- [ ] Open `POST /documents` to create a doc, then navigate to the returned URL
- [ ] Verify editor loads with content visible (no white screen)
- [ ] Verify WebSocket connects on port 4000 (green dot, no console errors)
- [ ] Verify `npm run dev` (Vite) still works correctly for development

🤖 Generated with [Claude Code](https://claude.com/claude-code)