### PR TITLE
feat(agent-bridge): add editV2 method with correct field names

### DIFF
--- a/packages/agent-bridge/src/index.ts
+++ b/packages/agent-bridge/src/index.ts
@@ -48,6 +48,21 @@ export interface AgentBridgePresenceInput {
   avatar?: string;
 }
 
+export type EditV2BlockOp =
+  | { op: 'replace_block'; ref: string; block: { markdown: string } }
+  | { op: 'insert_after'; ref: string; blocks: Array<{ markdown: string }> }
+  | { op: 'insert_before'; ref: string; blocks: Array<{ markdown: string }> }
+  | { op: 'delete_block'; ref: string }
+  | { op: 'replace_range'; fromRef: string; toRef: string; blocks: Array<{ markdown: string }> }
+  | { op: 'find_replace_in_block'; ref: string; find: string; replace: string; occurrence?: 'first' | 'all' };
+
+export interface EditV2Input {
+  by: string;
+  baseRevision: number;
+  operations: EditV2BlockOp[];
+  idempotencyKey?: string;
+}
+
 export interface AgentProviderMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
@@ -264,6 +279,16 @@ export function createAgentBridgeClient(config: AgentBridgeClientConfig) {
       return requestJson<T>(config, `${documentBasePath(slug)}/events/ack`, {
         method: 'POST',
         body: JSON.stringify(input),
+        ...options,
+      });
+    },
+    editV2<T = unknown>(slug: string, input: EditV2Input, options: AgentBridgeRequestOptions = {}): Promise<T> {
+      return requestJson<T>(config, `${documentBasePath(slug)}/edit/v2`, {
+        method: 'POST',
+        body: JSON.stringify(input),
+        headers: {
+          ...(input.idempotencyKey ? { 'Idempotency-Key': input.idempotencyKey } : {}),
+        },
         ...options,
       });
     },


### PR DESCRIPTION
Fixes #22

## Problem

The `editV2()` method was missing from the agent bridge client, and there was a field name mismatch between client expectations and server reality.

**Server expects** (from `server/agent-edit-v2.ts`):
- `baseRevision` (number)
- `operations` (array of block operations)

**What was missing:**
- No `editV2()` method in the bridge client
- No TypeScript types for edit v2 operations

## Solution

This PR adds:

✅ **`EditV2Input` interface** with correct field names matching the server  
✅ **`EditV2BlockOp` union type** covering all 6 operation types:
   - `replace_block`
   - `insert_after`
   - `insert_before`
   - `delete_block`
   - `replace_range`
   - `find_replace_in_block`

✅ **`editV2()` client method** that POSTs to `/documents/:slug/edit/v2`  
✅ **Idempotency-Key header support** (auto-set from `input.idempotencyKey`)

## Usage

```typescript
const bridge = createAgentBridgeClient({ baseUrl, auth: { shareToken } });

await bridge.editV2(slug, {
  by: 'ai:my-agent',
  baseRevision: 128,
  operations: [
    { op: 'replace_block', ref: 'b3', block: { markdown: '# Updated' } },
    { op: 'insert_after', ref: 'b3', blocks: [{ markdown: '## New section' }] }
  ],
  idempotencyKey: crypto.randomUUID()
});
```

## Testing

- ✅ Field names match server implementation
- ✅ All operation types from `server/agent-edit-v2.ts` are covered
- ✅ Idempotency header automatically included when key provided
- ✅ Follows existing bridge client patterns

## Related

- Resolves the API mismatch described in #22
- Aligns client types with `docs/agent-docs.md` examples
- Makes edit v2 (the recommended editing approach) actually usable from the bridge client