### PR TITLE
fix: bootstrap YDoc for API-created documents

### DIFF
--- a/server/collab.ts
+++ b/server/collab.ts
@@ -5713,6 +5713,20 @@ async function seedLegacyDocumentToPersistedYjsAsync(
     applyMarksMapDiff(ydoc.getMap('marks'), marks);
   }, 'legacy-seed-markdown');
   await seedFragmentFromLegacyMarkdown(ydoc, markdown);
+  // Sync the document row's markdown to the YDoc-derived version so that
+  // sameAuthoritativeContent() comparisons pass. Without this, API-created
+  // documents have a permanent mismatch (raw vs Milkdown-normalized markdown)
+  // that forces mutation_ready: false and breaks share view hydration.
+  const derivedMarkdown = await deriveMarkdownProjectionFromFragment(ydoc);
+  if (derivedMarkdown && derivedMarkdown.trim()) {
+    const derivedMarks = canonicalizeStoredMarks(encodeMarksMap(ydoc.getMap('marks')));
+    updateDocument(slug, derivedMarkdown, derivedMarks);
+    // Re-read the row so persistCanonicalYjsBaseline uses the normalized markdown
+    const updatedRow = getDocumentBySlug(slug);
+    if (updatedRow) {
+      return persistCanonicalYjsBaseline(slug, updatedRow, ydoc);
+    }
+  }
   return persistCanonicalYjsBaseline(slug, row, ydoc);
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,6 +16,7 @@ import {
   syncCanonicalDocumentStateToCollab,
   stripEphemeralCollabSpans,
   acquireRewriteLock,
+  ensureCanonicalYjsBaselineForDocument,
 } from './collab.js';
 import { getSnapshotPublicUrl, refreshSnapshotForSlug } from './snapshot.js';
 import { executeCanonicalRewrite, mutateCanonicalDocument } from './canonical-document.js';
@@ -784,7 +785,7 @@ function deriveShareCapabilities(role: ShareRole, shareState: string): {
 }
 
 // Create a shared document
-apiRoutes.post('/documents', (req: Request, res: Response) => {
+apiRoutes.post('/documents', async (req: Request, res: Response) => {
   const legacyCreateMode = resolveLegacyCreateMode(getPublicBaseUrl(req));
   if (legacyCreateMode === 'disabled') {
     recordLegacyCreateRouteTelemetry(req, legacyCreateMode, 'blocked_disabled');
@@ -827,6 +828,9 @@ apiRoutes.post('/documents', (req: Request, res: Response) => {
   const ownerSecret = randomUUID();
   const normalizedMarks = canonicalizeStoredMarks(marks ?? {});
   const doc = createDocument(slug, sanitizedMarkdown, normalizedMarks, title, ownerId, ownerSecret);
+  // Bootstrap YDoc so the collab system can hydrate the share view.
+  // Without this, API-created documents have no YDoc and the share view loads empty.
+  await ensureCanonicalYjsBaselineForDocument(slug);
   const defaultAccess = createDocumentAccessToken(slug, 'editor');
   const links = buildShareLink(req, doc.slug);
   const shareUrlWithToken = withShareToken(links.shareUrl, defaultAccess.secret);


### PR DESCRIPTION
## Summary

- Documents created via `POST /documents` never bootstrapped a Yjs document, so the share view loaded with an empty editor
- Root cause: the Milkdown round-trip normalizes markdown (whitespace, list formatting), creating a permanent mismatch between the DB row and YDoc-derived content. `sameAuthoritativeContent()` fails, forcing `mutation_ready: false` and `revision: null`
- Fix: call `ensureCanonicalYjsBaselineForDocument` after `createDocument()`, and sync the DB row's markdown to the YDoc-derived version so content comparisons pass

## Changes (2 files, +19 lines)

- **server/routes.ts**: Make `POST /documents` handler async, call `await ensureCanonicalYjsBaselineForDocument(slug)` after document creation
- **server/collab.ts**: In `seedLegacyDocumentToPersistedYjsAsync`, after seeding the YDoc fragment, derive the normalized markdown and update the document row to match

## Test plan

- [x] `POST /documents` returns `mutationReady: true`, `revision: 2`
- [x] Share view renders content with green dot (collab connected)
- [x] Editor is `contentEditable: true`
- [x] Browser edits persist to server (verified via `GET /state`)
- [x] Agent presence shows named collaborator (not anonymous)
- [x] Agent comments appear in browser in real-time
- [x] Rapid document creation (3 docs in <1s) — no race conditions
- [ ] Run `npm test` (existing test suite)

## Note

Local dev also requires `COLLAB_EMBEDDED_WS=1` env var so the WebSocket URL points to the same port as the HTTP server (the default assumes a separate WS port at `appPort + 1`).

Fixes #7