### PR TITLE
feat: add Dockerfile for self-hosted deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# ==============================================================
+# Stage 1: Install dependencies and build frontend
+# ==============================================================
+FROM node:22-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy workspace package.json files first for layer caching
+COPY package.json ./
+COPY packages/agent-bridge/package.json ./packages/agent-bridge/
+COPY packages/doc-core/package.json ./packages/doc-core/
+COPY packages/doc-editor/package.json ./packages/doc-editor/
+COPY packages/doc-server/package.json ./packages/doc-server/
+COPY packages/doc-store-sqlite/package.json ./packages/doc-store-sqlite/
+COPY apps/proof-example/package.json ./apps/proof-example/
+
+RUN npm install
+
+COPY . .
+
+# Build frontend SPA (Vite → dist/), then merge into public/ so the
+# Express static middleware can serve the built assets alongside existing
+# static files, then prune dev dependencies.
+# Single RUN so dev deps don't persist in any layer.
+RUN npm run build \
+    && cp -r dist/* public/ \
+    && npm prune --omit=dev
+
+# ==============================================================
+# Stage 2: Production runtime
+# ==============================================================
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g tsx@4 && npm cache clean --force
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+RUN chown node:node /app
+
+# Server source and shared modules it imports at runtime
+COPY --from=builder --chown=node:node /app/server ./server
+COPY --from=builder --chown=node:node /app/src ./src
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/docs/agent-docs.md ./docs/
+COPY --from=builder --chown=node:node /app/AGENT_CONTRACT.md ./
+COPY --from=builder --chown=node:node /app/package.json ./
+
+RUN mkdir -p /data && chown node:node /data
+
+USER node
+
+EXPOSE 4000
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["tsx", "server/index.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ COPY . .
 # Build frontend SPA (Vite → dist/), then merge into public/ so the
 # Express static middleware can serve the built assets alongside existing
 # static files, then prune dev dependencies.
-# Single RUN so dev deps don't persist in any layer.
+# Single RUN so build + asset merge + prune happen together, and only
+# pruned dependencies are copied into the runtime image.
 RUN npm run build \
     && cp -r dist/* public/ \
     && npm prune --omit=dev
@@ -39,7 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dumb-init \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g tsx@4 && npm cache clean --force
+RUN npm install -g tsx@4.21.0 && npm cache clean --force
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Hey, thanks for releasing Proof. I started using it, hosting it myself, and this is the Dockerfile I'm using. Thought it would be great to share.

## Summary

Add a multi-stage Dockerfile so anyone can self-host the Proof SDK server with `docker build && docker run`.

## Why

No official way to run Proof SDK in a container. This makes self-hosting straightforward: build the image, run it, configure with environment variables.

## What

- Multi-stage build: builder stage compiles native modules (`better-sqlite3`) and builds the Vite frontend, production stage is a clean `node:22-slim`
- Use `tsx` for server execution (same as `npm run serve`) since `src/` files don't compile cleanly under `tsconfig.server.json`
- Copy `dist/*` into `public/` so the Express static middleware serves built assets (the server reads from both directories)
- Run as non-root `node` user with `dumb-init` for proper signal handling
- No secrets in layers: all config via runtime environment variables

### Environment variables

| Variable | Required | Default | Purpose |
|---|---|---|---|
| `DATABASE_PATH` | No | `proof-share.db` | SQLite database path |
| `PORT` | No | `4000` | Server port |
| `PROOF_PUBLIC_BASE_URL` | Yes (HTTPS) | - | Public URL for WebSocket URLs |
| `PROOF_COLLAB_SIGNING_SECRET` | Yes (non-local) | - | Required when public URL is non-localhost |
| `PROOF_CORS_ALLOW_ORIGINS` | No | localhost | Comma-separated allowed origins |
| `SNAPSHOT_DIR` | No | `snapshots/` | Snapshot directory |

### Usage

```bash
docker build -t proof-sdk .
docker run -d \
  -p 4000:4000 \
  -v proof-data:/data \
  -e DATABASE_PATH=/data/proof-share.db \
  -e PROOF_PUBLIC_BASE_URL=https://proof.example.com \
  -e PROOF_COLLAB_SIGNING_SECRET=$(openssl rand -hex 32) \
  proof-sdk
```

### Compose example

```yaml
services:
  proof:
    build: .
    image: proof-sdk:latest
    container_name: proof
    restart: unless-stopped
    ports:
      - "4000:4000"
    environment:
      DATABASE_PATH: /data/proof-share.db
      PROOF_COLLAB_SIGNING_SECRET: ${PROOF_COLLAB_SIGNING_SECRET}
      PROOF_PUBLIC_BASE_URL: ${PROOF_PUBLIC_BASE_URL:-http://localhost:4000}
      # PROOF_CORS_ALLOW_ORIGINS: "https://proof.example.com"
    volumes:
      - proof-data:/data

volumes:
  proof-data:
```

### Known limitation

The repo gitignores `package-lock.json`, so the build uses `npm install` instead of `npm ci`. Dependency versions may drift between builds.