### PR TITLE
fix: relay Ask Proof comment to server ops endpoint so HTTP agents can poll it

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -5414,6 +5414,30 @@ class ProofEditorImpl implements ProofEditor {
     if (selectedText.trim()) {
       // Create a comment with @proof mention to trigger the agent
       markComment(view, selectedText, actor, `@proof ${prompt}`, context.range);
+
+      // Also POST to the server ops endpoint so the agent can poll it via HTTP.
+      // The local Yjs mark is not visible to HTTP readers while a live collab
+      // session is active (projection repair is blocked by the collab lease).
+      const slug = shareClient.getSlug();
+      if (slug) {
+        const body = JSON.stringify({
+          type: 'comment.add',
+          by: actor,
+          quote: selectedText,
+          text: `@proof ${prompt}`,
+        });
+        fetch(`${shareClient.getApiBaseUrl()}/agent/${encodeURIComponent(slug)}/ops`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...shareClient.getShareAuthHeaders(),
+          },
+          body,
+        }).catch((err) => {
+          console.warn('[invokeAgentOnSelection] Failed to POST comment to server ops:', err);
+        });
+      }
+
       captureEvent('agent_manual_request_queued', {
         trigger_type: 'comment',
       });


### PR DESCRIPTION
## Problem

`invokeAgentOnSelection` creates a ProseMirror mark via `markComment` and writes it into the local Yjs document. While a live collab session is active, the server blocks projection repair with `blockedReason: recent_live_collab_lease` — so any HTTP-polling agent calling `/state`, `/marks`, or the bridge endpoints will see empty marks and never receive the request.

The code comment already acknowledged this was incomplete:

```ts
// Import and use the agent session manager (will be created in Phase 1)
// For now, create a comment with the request for @proof to handle
```

But "Phase 1" was never wired up, leaving the Ask Proof UI with no backend path to an actual agent.

## Fix

After creating the local mark, also fire a `POST` to `/api/agent/:slug/ops` with `type: comment.add`. This writes directly to the server's ops table in SQLite, bypassing the Yjs-to-projection pipeline. Any HTTP-polling agent sees the Ask Proof request immediately, regardless of collab lease state.

The local `markComment` call is preserved so the inline mark still appears in the editor.

```ts
fetch(`${shareClient.getApiBaseUrl()}/agent/${encodeURIComponent(slug)}/ops`, {
  method: 'POST',
  headers: { 'Content-Type': 'application/json', ...shareClient.getShareAuthHeaders() },
  body: JSON.stringify({ type: 'comment.add', by: actor, quote: selectedText, text: `@proof ${prompt}` }),
}).catch((err) => {
  console.warn('[invokeAgentOnSelection] Failed to POST comment to server ops:', err);
});
```

## Why this matters

Without this fix, the Ask Proof UI creates a strong expectation that an agent is listening — but nothing ever closes that loop. The feature is silently broken for any HTTP-based agent integration.

## Testing

1. Open a shared doc with an HTTP-polling agent connected
2. Select text and use Ask Proof (right-click or ⇧⌘P)
3. Agent receives the comment via `GET /api/agent/:slug/events/pending` within the same polling cycle