### PR TITLE
feat: pluggable auth strategy (none, local, workos)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ VITE_APP_VERSION=dev
 # WorkOS credentials (required when PROOF_AUTH_STRATEGY=workos)
 # WORKOS_API_KEY=sk_test_...
 # WORKOS_CLIENT_ID=client_...
+# WORKOS_COOKIE_PASSWORD= (min 32 chars, used to seal WorkOS sessions; generate with: openssl rand -hex 16)
 
 # Comma-separated WorkOS organization IDs allowed to access this instance.
 # Leave empty to allow all organizations (no org restriction).

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ VITE_APP_VERSION=dev
 
 # --- Auth Strategy ---
 
-# Auth strategy: 'none' (default, no auth) or 'workos' (WorkOS AuthKit)
+# Auth strategy: 'none' (default, no auth), 'workos' (WorkOS AuthKit), or 'local' (email/password)
 # PROOF_AUTH_STRATEGY=none
 
 # WorkOS credentials (required when PROOF_AUTH_STRATEGY=workos)
@@ -34,3 +34,7 @@ VITE_APP_VERSION=dev
 # Comma-separated WorkOS organization IDs allowed to access this instance.
 # Leave empty to allow all organizations (no org restriction).
 # PROOF_ALLOWED_ORG_IDS=org_abc123
+
+# Invite code for local auth registration (when PROOF_AUTH_STRATEGY=local).
+# When set, users must enter this code to register. When unset, open registration.
+# PROOF_LOCAL_INVITE_CODE=your-secret-invite-code

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,21 @@ VITE_ENABLE_TELEMETRY=false
 
 # Optional app version tag for event properties
 VITE_APP_VERSION=dev
+
+# --- Docker / Production ---
+
+# Server port (default: 5555)
+# PORT=5555
+
+# SQLite database path (default: ./proof-share.db, use /data/proof-share.db in Docker)
+# DATABASE_PATH=/data/proof-share.db
+
+# Required for production: signing secret for collab session tokens.
+# Generate with: openssl rand -hex 32
+# PROOF_COLLAB_SIGNING_SECRET=
+
+# Public base URL for share links (set to your fly.io URL in production)
+# PROOF_PUBLIC_BASE_URL=https://your-app.fly.dev
+
+# CORS origins (comma-separated). Defaults to localhost if unset.
+# PROOF_CORS_ALLOW_ORIGINS=https://your-app.fly.dev

--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,16 @@ VITE_APP_VERSION=dev
 
 # CORS origins (comma-separated). Defaults to localhost if unset.
 # PROOF_CORS_ALLOW_ORIGINS=https://your-app.fly.dev
+
+# --- Auth Strategy ---
+
+# Auth strategy: 'none' (default, no auth) or 'workos' (WorkOS AuthKit)
+# PROOF_AUTH_STRATEGY=none
+
+# WorkOS credentials (required when PROOF_AUTH_STRATEGY=workos)
+# WORKOS_API_KEY=sk_test_...
+# WORKOS_CLIENT_ID=client_...
+
+# Comma-separated WorkOS organization IDs allowed to access this instance.
+# Leave empty to allow all organizations (no org restriction).
+# PROOF_ALLOWED_ORG_IDS=org_abc123

--- a/AGENT_CONTRACT.md
+++ b/AGENT_CONTRACT.md
@@ -148,7 +148,7 @@ Send `Idempotency-Key` on mutation requests so retries stay safe.
 ## CLI Example
 
 ```bash
-curl -X POST http://localhost:4000/documents \
+curl -X POST http://localhost:5555/documents \
   -H "Content-Type: application/json" \
   -d '{"markdown":"# Plan\n\nShip the rewrite.","title":"Rewrite Plan","role":"commenter"}'
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# ==============================================================
+# Stage 1: Install dependencies and build frontend
+# ==============================================================
+FROM node:22-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy workspace package.json files first for layer caching
+COPY package.json ./
+COPY packages/agent-bridge/package.json ./packages/agent-bridge/
+COPY packages/doc-core/package.json ./packages/doc-core/
+COPY packages/doc-editor/package.json ./packages/doc-editor/
+COPY packages/doc-server/package.json ./packages/doc-server/
+COPY packages/doc-store-sqlite/package.json ./packages/doc-store-sqlite/
+COPY apps/proof-example/package.json ./apps/proof-example/
+
+RUN npm install
+
+COPY . .
+
+# Build frontend SPA (Vite → dist/), then merge into public/ so the
+# Express static middleware can serve the built assets alongside existing
+# static files, then prune dev dependencies.
+# Single RUN so dev deps don't persist in any layer.
+RUN npm run build \
+    && cp -r dist/* public/ \
+    && npm prune --omit=dev
+
+# ==============================================================
+# Stage 2: Production runtime
+# ==============================================================
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g tsx@4 && npm cache clean --force
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+RUN chown node:node /app
+
+# Server source and shared modules it imports at runtime
+COPY --from=builder --chown=node:node /app/server ./server
+COPY --from=builder --chown=node:node /app/src ./src
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/docs/agent-docs.md ./docs/
+COPY --from=builder --chown=node:node /app/AGENT_CONTRACT.md ./
+COPY --from=builder --chown=node:node /app/package.json ./
+
+RUN mkdir -p /data && chown node:node /data
+
+USER node
+
+EXPOSE 4000
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["tsx", "server/index.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir -p /data && chown node:node /data
 
 USER node
 
-EXPOSE 4000
+EXPOSE 5555
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["tsx", "server/index.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ COPY . .
 # Build frontend SPA (Vite → dist/), then merge into public/ so the
 # Express static middleware can serve the built assets alongside existing
 # static files, then prune dev dependencies.
-# Single RUN so dev deps don't persist in any layer.
+# Single RUN so build + asset merge + prune happen together, and only
+# pruned dependencies are copied into the runtime image.
 RUN npm run build \
     && cp -r dist/* public/ \
     && npm prune --omit=dev
@@ -39,7 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dumb-init \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g tsx@4 && npm cache clean --force
+RUN npm install -g tsx@4.21.0 && npm cache clean --force
 
 ENV NODE_ENV=production
 

--- a/README.md
+++ b/README.md
@@ -8,60 +8,92 @@ If you want the hosted product, use [Proof](https://proofeditor.ai). Hosted Proo
 
 - Collaborative markdown editor with provenance tracking
 - Comments, suggestions, and rewrite operations
-- Realtime collaboration server
+- Realtime collaboration server (WebSocket + Yjs)
 - Agent HTTP bridge for state, marks, edits, presence, and events
+- Landing page with agent setup instructions
+- Docker and Fly.io deployment support
 - A small example app under `apps/proof-example`
 
-## Workspace Layout
-
-- `packages/doc-core`
-- `packages/doc-editor`
-- `packages/doc-server`
-- `packages/doc-store-sqlite`
-- `packages/agent-bridge`
-- `apps/proof-example`
-- `server`
-- `src`
-
-## Local Development
-
-Requirements:
-
-- Node.js 18+
-
-Install dependencies:
+## Quick Start
 
 ```bash
 npm install
 ```
 
-Start the editor:
+Start both the server and the editor for local development:
 
 ```bash
+# Terminal 1 — API server
+npm run serve
+
+# Terminal 2 — Editor (Vite dev server with hot reload)
 npm run dev
 ```
 
-Start the local server:
+Then open `http://localhost:5555`. Click **Get started** to create a document and open the editor with the welcome flow.
+
+The API server runs on port **5555** and the Vite dev server on port **5556** (proxies API requests to 5555 automatically).
+
+## Docker
+
+Run the full stack in a single container (no separate Vite server needed — built assets are served by Express):
 
 ```bash
-npm run serve
+# 1. Copy and configure environment
+cp .env.example .env
+echo "PROOF_COLLAB_SIGNING_SECRET=$(openssl rand -hex 32)" >> .env
+
+# 2. Start
+docker compose up --build -d
 ```
 
-The default setup serves the editor on `http://localhost:3000` and the API/server on `http://localhost:4000`.
+Open `http://localhost:5555`.
+
+## Deploy to Fly.io
+
+```bash
+# 1. Create the app and volume
+fly launch --no-deploy
+fly volumes create proof_data --size 1 --region iad
+
+# 2. Set secrets
+fly secrets set PROOF_COLLAB_SIGNING_SECRET=$(openssl rand -hex 32)
+fly secrets set PROOF_PUBLIC_BASE_URL=https://your-app.fly.dev
+
+# 3. Deploy
+fly deploy
+```
+
+Set `PROOF_CORS_ALLOW_ORIGINS=https://your-app.fly.dev` if you need cross-origin access from a separate frontend.
+
+## Workspace Layout
+
+| Path | Description |
+|------|-------------|
+| `server/` | Express API server, collab runtime, agent bridge |
+| `src/` | Editor frontend, bridge clients, tests |
+| `packages/doc-core` | Core document model |
+| `packages/doc-editor` | Editor components |
+| `packages/doc-server` | Server-side document logic |
+| `packages/doc-store-sqlite` | SQLite persistence layer |
+| `packages/agent-bridge` | Agent HTTP bridge |
+| `apps/proof-example` | Example app |
 
 ## Core Routes
 
 Canonical Proof SDK routes:
 
-- `POST /documents`
-- `GET /documents/:slug/state`
-- `GET /documents/:slug/snapshot`
-- `POST /documents/:slug/edit`
-- `POST /documents/:slug/edit/v2`
-- `POST /documents/:slug/ops`
-- `POST /documents/:slug/presence`
-- `GET /documents/:slug/events/pending`
-- `POST /documents/:slug/events/ack`
+- `POST /documents` — create a new document
+- `GET /documents/:slug/state` — read document state
+- `GET /documents/:slug/snapshot` — block-level snapshot with base token
+- `POST /documents/:slug/edit/v2` — structural block edits
+- `POST /documents/:slug/ops` — comments, suggestions, rewrites
+- `POST /documents/:slug/presence` — agent presence
+- `GET /documents/:slug/events/pending` — poll for events
+- `POST /documents/:slug/events/ack` — acknowledge events
+
+Bridge routes (for embedded editor integration):
+
 - `GET /documents/:slug/bridge/state`
 - `GET /documents/:slug/bridge/marks`
 - `POST /documents/:slug/bridge/comments`
@@ -69,7 +101,17 @@ Canonical Proof SDK routes:
 - `POST /documents/:slug/bridge/rewrite`
 - `POST /documents/:slug/bridge/presence`
 
-Compatibility aliases remain mounted for the hosted product, but the routes above are the public SDK surface.
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PORT` | No | `5555` | Server port |
+| `DATABASE_PATH` | No | `./proof-share.db` | SQLite database path |
+| `PROOF_COLLAB_SIGNING_SECRET` | Production | — | Signing secret for collab session tokens |
+| `PROOF_PUBLIC_BASE_URL` | Production | — | Public URL for share links and WebSocket URLs |
+| `PROOF_CORS_ALLOW_ORIGINS` | No | localhost | Comma-separated allowed CORS origins |
+| `COLLAB_EMBEDDED_WS` | Docker | — | Set to `true` when WebSocket runs on the same port |
+| `PROOF_TRUST_PROXY_HEADERS` | Production | — | Set to `true` behind a reverse proxy |
 
 ## Build
 
@@ -87,10 +129,9 @@ npm test
 
 ## Docs
 
-- `AGENT_CONTRACT.md`
-- `docs/agent-docs.md`
-- `docs/proof.SKILL.md`
-- `docs/adr/2026-03-proof-sdk-public-core.md`
+- `AGENT_CONTRACT.md` — document creation and mutation contract
+- `docs/agent-docs.md` — full agent API reference
+- `docs/proof.SKILL.md` — agent skill file for Claude Code, Codex, etc.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ Run the full stack in a single container (no separate Vite server needed — bui
 cp .env.example .env
 echo "PROOF_COLLAB_SIGNING_SECRET=$(openssl rand -hex 32)" >> .env
 
-# 2. Start
+# 2. Optional: enable auth
+echo "PROOF_AUTH_STRATEGY=local" >> .env
+echo "PROOF_LOCAL_INVITE_CODE=your-secret" >> .env
+
+# 3. Start
 docker compose up --build -d
 ```
 
@@ -60,7 +64,18 @@ fly volumes create proof_data --size 1 --region iad
 fly secrets set PROOF_COLLAB_SIGNING_SECRET=$(openssl rand -hex 32)
 fly secrets set PROOF_PUBLIC_BASE_URL=https://your-app.fly.dev
 
-# 3. Deploy
+# 3. Optional: enable auth
+fly secrets set PROOF_AUTH_STRATEGY=local
+fly secrets set PROOF_LOCAL_INVITE_CODE=your-secret
+
+# Or for WorkOS:
+# fly secrets set PROOF_AUTH_STRATEGY=workos
+# fly secrets set WORKOS_API_KEY=sk_...
+# fly secrets set WORKOS_CLIENT_ID=client_...
+# fly secrets set WORKOS_COOKIE_PASSWORD=$(openssl rand -hex 16)
+# fly secrets set PROOF_ALLOWED_ORG_IDS=org_...
+
+# 4. Deploy
 fly deploy
 ```
 
@@ -101,6 +116,46 @@ Bridge routes (for embedded editor integration):
 - `POST /documents/:slug/bridge/rewrite`
 - `POST /documents/:slug/bridge/presence`
 
+## Authentication
+
+Proof SDK supports pluggable authentication via `PROOF_AUTH_STRATEGY`:
+
+| Strategy | Description |
+|----------|-------------|
+| `none` | Default. No authentication — anyone can access the instance. |
+| `local` | Email/password accounts with optional invite-code gating. |
+| `workos` | WorkOS AuthKit SSO with organization-level access control. |
+
+### Local auth (email/password)
+
+```bash
+# Open registration
+PROOF_AUTH_STRATEGY=local npm run serve
+
+# Invite-code gated registration
+PROOF_AUTH_STRATEGY=local PROOF_LOCAL_INVITE_CODE=your-secret npm run serve
+```
+
+Users register at `/auth/register` and log in at `/auth/login`. Account settings (name, email, password) are at `/auth/account`.
+
+### WorkOS auth (SSO)
+
+```bash
+PROOF_AUTH_STRATEGY=workos \
+WORKOS_API_KEY=sk_... \
+WORKOS_CLIENT_ID=client_... \
+WORKOS_COOKIE_PASSWORD=$(openssl rand -hex 16) \
+PROOF_ALLOWED_ORG_IDS=org_... \
+npm run serve
+```
+
+Add your callback URL (`http://localhost:5555/api/auth/callback`) in the WorkOS dashboard. Set `PROOF_ALLOWED_ORG_IDS` to restrict access to specific organizations.
+
+### Adding a new strategy
+
+1. Create `server/auth/my-strategy.ts` implementing `AuthStrategy` from `server/auth/strategy.ts`.
+2. Add a `case` in `server/auth/index.ts`.
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |
@@ -112,6 +167,12 @@ Bridge routes (for embedded editor integration):
 | `PROOF_CORS_ALLOW_ORIGINS` | No | localhost | Comma-separated allowed CORS origins |
 | `COLLAB_EMBEDDED_WS` | Docker | — | Set to `true` when WebSocket runs on the same port |
 | `PROOF_TRUST_PROXY_HEADERS` | Production | — | Set to `true` behind a reverse proxy |
+| `PROOF_AUTH_STRATEGY` | No | `none` | Auth strategy: `none`, `local`, or `workos` |
+| `PROOF_LOCAL_INVITE_CODE` | No | — | Invite code for local registration (when set, required to register) |
+| `WORKOS_API_KEY` | WorkOS | — | WorkOS API key |
+| `WORKOS_CLIENT_ID` | WorkOS | — | WorkOS client ID |
+| `WORKOS_COOKIE_PASSWORD` | WorkOS | — | Secret for sealing WorkOS sessions (min 32 chars) |
+| `PROOF_ALLOWED_ORG_IDS` | No | — | Comma-separated WorkOS org IDs allowed access |
 
 ## Build
 

--- a/apps/proof-example/README.md
+++ b/apps/proof-example/README.md
@@ -22,7 +22,7 @@ npm run proof-sdk:demo:agent
 
 Environment variables:
 
-- `PROOF_BASE_URL`: defaults to `http://127.0.0.1:4000`
+- `PROOF_BASE_URL`: defaults to `http://127.0.0.1:5555`
 - `PROOF_DEMO_TITLE`: optional document title override
 - `PROOF_DEMO_MARKDOWN`: optional initial markdown override
 

--- a/apps/proof-example/examples/agent-http-bridge.ts
+++ b/apps/proof-example/examples/agent-http-bridge.ts
@@ -50,7 +50,7 @@ async function createDocument(baseUrl: string, title: string, markdown: string):
 }
 
 async function run(): Promise<void> {
-  const baseUrl = (process.env.PROOF_BASE_URL || 'http://127.0.0.1:4000').replace(/\/+$/, '');
+  const baseUrl = (process.env.PROOF_BASE_URL || 'http://127.0.0.1:5555').replace(/\/+$/, '');
   const title = process.env.PROOF_DEMO_TITLE || 'Proof SDK Example';
   const markdown = process.env.PROOF_DEMO_MARKDOWN || '# Hello\n\nThis draft needs a stronger opening.';
   const provider = new DemoAgentProvider();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       PROOF_LOCAL_INVITE_CODE: "${PROOF_LOCAL_INVITE_CODE:-}"
       WORKOS_API_KEY: "${WORKOS_API_KEY:-}"
       WORKOS_CLIENT_ID: "${WORKOS_CLIENT_ID:-}"
+      WORKOS_COOKIE_PASSWORD: "${WORKOS_COOKIE_PASSWORD:-}"
       PROOF_ALLOWED_ORG_IDS: "${PROOF_ALLOWED_ORG_IDS:-}"
       NODE_ENV: production
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  proof-sdk:
+    build: .
+    ports:
+      - "${PORT:-5555}:${PORT:-5555}"
+    volumes:
+      - proof-data:/data
+    environment:
+      PORT: "${PORT:-5555}"
+      DATABASE_PATH: /data/proof-share.db
+      PROOF_COLLAB_SIGNING_SECRET: "${PROOF_COLLAB_SIGNING_SECRET:?Set PROOF_COLLAB_SIGNING_SECRET in .env or environment}"
+      PROOF_PUBLIC_BASE_URL: "${PROOF_PUBLIC_BASE_URL:-http://localhost:${PORT:-5555}}"
+      PROOF_CORS_ALLOW_ORIGINS: "${PROOF_CORS_ALLOW_ORIGINS:-}"
+      COLLAB_EMBEDDED_WS: "true"
+      NODE_ENV: production
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:${PORT:-5555}/health').then(r=>{if(!r.ok)throw 1})"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  proof-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       PROOF_PUBLIC_BASE_URL: "${PROOF_PUBLIC_BASE_URL:-http://localhost:${PORT:-5555}}"
       PROOF_CORS_ALLOW_ORIGINS: "${PROOF_CORS_ALLOW_ORIGINS:-}"
       COLLAB_EMBEDDED_WS: "true"
+      PROOF_AUTH_STRATEGY: "${PROOF_AUTH_STRATEGY:-none}"
+      PROOF_LOCAL_INVITE_CODE: "${PROOF_LOCAL_INVITE_CODE:-}"
+      WORKOS_API_KEY: "${WORKOS_API_KEY:-}"
+      WORKOS_CLIENT_ID: "${WORKOS_CLIENT_ID:-}"
+      PROOF_ALLOWED_ORG_IDS: "${PROOF_ALLOWED_ORG_IDS:-}"
       NODE_ENV: production
     restart: unless-stopped
     healthcheck:

--- a/docs/agent-docs.md
+++ b/docs/agent-docs.md
@@ -43,17 +43,17 @@ No browser automation is required. Use HTTP directly (for example, `curl` or you
 
 If you received a shared link like:
 
-  http://localhost:4000/d/<slug>?token=<token>
+  http://localhost:5555/d/<slug>?token=<token>
 
 You can discover the API and read the document in one step using **content negotiation** on that same URL.
 
 Fetch JSON (recommended):
 
-  curl -H "Accept: application/json" "http://localhost:4000/d/<slug>?token=<token>"
+  curl -H "Accept: application/json" "http://localhost:5555/d/<slug>?token=<token>"
 
 Fetch raw markdown:
 
-  curl -H "Accept: text/markdown" "http://localhost:4000/d/<slug>?token=<token>"
+  curl -H "Accept: text/markdown" "http://localhost:5555/d/<slug>?token=<token>"
 
 The JSON response includes:
 - `markdown` (document content)
@@ -63,13 +63,13 @@ The JSON response includes:
 ### Quick copy/paste flow (token already in the shared URL)
 
 ```bash
-SHARE_URL='http://localhost:4000/d/<slug>?token=<token>'
+SHARE_URL='http://localhost:5555/d/<slug>?token=<token>'
 TOKEN='<token>'
 SLUG='<slug>'
 
 curl -H "Accept: application/json" "$SHARE_URL"
 curl -H "Accept: text/markdown" "$SHARE_URL"
-curl -H "Authorization: Bearer $TOKEN" -H "X-Agent-Id: your-agent" "http://localhost:4000/documents/$SLUG/state"
+curl -H "Authorization: Bearer $TOKEN" -H "X-Agent-Id: your-agent" "http://localhost:5555/documents/$SLUG/state"
 ```
 
 ## Auth: Token From URL
@@ -89,28 +89,28 @@ Use:
 
 Add a comment:
 
-  curl -X POST "http://localhost:4000/documents/<slug>/ops?token=<token>" \
+  curl -X POST "http://localhost:5555/documents/<slug>/ops?token=<token>" \
     -H "Content-Type: application/json" \
     -H "X-Agent-Id: your-agent" \
     -d '{"type":"comment.add","by":"ai:your-agent","quote":"text to anchor","text":"comment body"}'
 
 Suggest a replace:
 
-  curl -X POST "http://localhost:4000/documents/<slug>/ops?token=<token>" \
+  curl -X POST "http://localhost:5555/documents/<slug>/ops?token=<token>" \
     -H "Content-Type: application/json" \
     -H "X-Agent-Id: your-agent" \
     -d '{"type":"suggestion.add","by":"ai:your-agent","kind":"replace","quote":"old text","content":"new text"}'
 
 Create and immediately apply a suggestion:
 
-  curl -X POST "http://localhost:4000/documents/<slug>/ops?token=<token>" \
+  curl -X POST "http://localhost:5555/documents/<slug>/ops?token=<token>" \
     -H "Content-Type: application/json" \
     -H "X-Agent-Id: your-agent" \
     -d '{"type":"suggestion.add","by":"ai:your-agent","kind":"replace","quote":"old text","content":"new text","status":"accepted"}'
 
 Rewrite the whole document:
 
-  curl -X POST "http://localhost:4000/documents/<slug>/ops?token=<token>" \
+  curl -X POST "http://localhost:5555/documents/<slug>/ops?token=<token>" \
     -H "Content-Type: application/json" \
     -H "X-Agent-Id: your-agent" \
     -d '{"type":"rewrite.apply","by":"ai:your-agent","content":"# New markdown..."}'
@@ -129,7 +129,7 @@ The body must include an `operations` array (max 50 ops) and a `by` field for au
 
 Add content at the end of a named section (matched by heading text):
 
-  curl -X POST "http://localhost:4000/documents/<slug>/edit" \
+  curl -X POST "http://localhost:5555/documents/<slug>/edit" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <token>" \
     -H "X-Agent-Id: your-agent" \
@@ -146,7 +146,7 @@ The `section` value is matched against heading text (e.g., `"Brandon"` matches `
 
 Find and replace a specific string in the document:
 
-  curl -X POST "http://localhost:4000/documents/<slug>/edit" \
+  curl -X POST "http://localhost:5555/documents/<slug>/edit" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <token>" \
     -H "X-Agent-Id: your-agent" \
@@ -161,7 +161,7 @@ Find and replace a specific string in the document:
 
 Insert content after a specific anchor string:
 
-  curl -X POST "http://localhost:4000/documents/<slug>/edit" \
+  curl -X POST "http://localhost:5555/documents/<slug>/edit" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <token>" \
     -H "X-Agent-Id: your-agent" \
@@ -178,7 +178,7 @@ Insert content after a specific anchor string:
 
 You can combine operations in a single request (applied in order):
 
-  curl -X POST "http://localhost:4000/documents/<slug>/edit" \
+  curl -X POST "http://localhost:5555/documents/<slug>/edit" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <token>" \
     -H "X-Agent-Id: your-agent" \
@@ -227,7 +227,7 @@ Use:
 
 Example:
 
-  curl -X PUT "http://localhost:4000/documents/<slug>/title" \
+  curl -X PUT "http://localhost:5555/documents/<slug>/title" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <token>" \
     -d '{"title":"Updated document title"}'
@@ -245,7 +245,7 @@ Use v2 for top-level block edits with stable block IDs and revision-based optimi
 
 Example:
 
-  curl -H "Authorization: Bearer <token>" "http://localhost:4000/documents/<slug>/snapshot"
+  curl -H "Authorization: Bearer <token>" "http://localhost:5555/documents/<slug>/snapshot"
 
 The response includes `revision` and an ordered `blocks` array with deterministic refs (`b1`, `b2`, ...).
 
@@ -255,7 +255,7 @@ The response includes `revision` and an ordered `blocks` array with deterministi
 
 Example:
 
-  curl -X POST "http://localhost:4000/documents/<slug>/edit/v2" \
+  curl -X POST "http://localhost:5555/documents/<slug>/edit/v2" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <token>" \
     -H "Idempotency-Key: <uuid>" \
@@ -343,7 +343,7 @@ This is the most reliable way to add a line, row, or section to an existing docu
 
 ### Step 1: Get the snapshot
 
-  curl -H "Authorization: Bearer <token>" "http://localhost:4000/documents/<slug>/snapshot"
+  curl -H "Authorization: Bearer <token>" "http://localhost:5555/documents/<slug>/snapshot"
 
 This returns clean markdown per block (no internal HTML tags) plus stable `ref` identifiers and a `revision` number.
 ### Step 2: Find the right block
@@ -355,7 +355,7 @@ Look through the `blocks` array for the block you want to edit or insert near. E
 
 ### Step 3: Apply your edit
 
-  curl -X POST "http://localhost:4000/documents/<slug>/edit/v2" \
+  curl -X POST "http://localhost:5555/documents/<slug>/edit/v2" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <token>" \
     -H "Idempotency-Key: <uuid>" \

--- a/docs/proof.SKILL.md
+++ b/docs/proof.SKILL.md
@@ -18,7 +18,7 @@ Proof is the hosted product. Proof SDK is the open-source editor, collaboration 
 Shared URL format:
 
 ```text
-http://localhost:4000/d/<slug>?token=<token>
+http://localhost:5555/d/<slug>?token=<token>
 ```
 
 Use one of:
@@ -32,7 +32,7 @@ Use one of:
 ### Create a document
 
 ```bash
-curl -sS -X POST http://localhost:4000/documents \
+curl -sS -X POST http://localhost:5555/documents \
   -H "Content-Type: application/json" \
   -d '{"title":"My Document","markdown":"# Hello\n\nFirst draft."}'
 ```
@@ -42,7 +42,7 @@ Hosted Proof also keeps `POST /share/markdown` as a compatibility alias.
 ### Read state
 
 ```bash
-curl -sS "http://localhost:4000/documents/<slug>/state" \
+curl -sS "http://localhost:5555/documents/<slug>/state" \
   -H "Authorization: Bearer <token>" \
   -H "X-Agent-Id: <your-agent-id>"
 ```
@@ -52,21 +52,21 @@ Include `X-Agent-Id` on `GET /state` only when you want presence to appear for t
 Content negotiation also works directly on shared links:
 
 ```bash
-curl -sS -H "Accept: application/json" "http://localhost:4000/d/<slug>?token=<token>"
-curl -sS -H "Accept: text/markdown" "http://localhost:4000/d/<slug>?token=<token>"
+curl -sS -H "Accept: application/json" "http://localhost:5555/d/<slug>?token=<token>"
+curl -sS -H "Accept: text/markdown" "http://localhost:5555/d/<slug>?token=<token>"
 ```
 
 ### Get a snapshot for structured edits
 
 ```bash
-curl -sS "http://localhost:4000/documents/<slug>/snapshot" \
+curl -sS "http://localhost:5555/documents/<slug>/snapshot" \
   -H "Authorization: Bearer <token>"
 ```
 
 ### Apply block edits with `edit/v2`
 
 ```bash
-curl -sS -X POST "http://localhost:4000/documents/<slug>/edit/v2" \
+curl -sS -X POST "http://localhost:5555/documents/<slug>/edit/v2" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -H "Idempotency-Key: <unique-key>" \
@@ -111,14 +111,14 @@ POST /documents/<slug>/events/ack
 ### Poll events
 
 ```bash
-curl -sS "http://localhost:4000/documents/<slug>/events/pending?after=0" \
+curl -sS "http://localhost:5555/documents/<slug>/events/pending?after=0" \
   -H "Authorization: Bearer <token>"
 ```
 
 ### Send presence
 
 ```bash
-curl -sS -X POST "http://localhost:4000/documents/<slug>/presence" \
+curl -sS -X POST "http://localhost:5555/documents/<slug>/presence" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -H "X-Agent-Id: <your-agent-id>" \
@@ -155,8 +155,8 @@ curl -sS -X POST "http://localhost:4000/documents/<slug>/presence" \
 
 ## References
 
-- Discovery JSON: `http://localhost:4000/.well-known/agent.json`
-- Docs: `http://localhost:4000/agent-docs`
-- Setup: `http://localhost:4000/agent-setup`
+- Discovery JSON: `http://localhost:5555/.well-known/agent.json`
+- Docs: `http://localhost:5555/agent-docs`
+- Setup: `http://localhost:5555/agent-setup`
 - [AGENT_CONTRACT.md](/Users/danshipper/CascadeProjects/every-proof/.worktrees/proof-sdk-split/AGENT_CONTRACT.md)
 - [agent-docs.md](/Users/danshipper/CascadeProjects/every-proof/.worktrees/proof-sdk-split/docs/agent-docs.md)

--- a/docs/superpowers/specs/2026-04-09-local-auth-strategy-design.md
+++ b/docs/superpowers/specs/2026-04-09-local-auth-strategy-design.md
@@ -1,0 +1,80 @@
+# Local Auth Strategy Design
+
+**Date:** 2026-04-09
+
+## Goal
+
+Add a `local` auth strategy to the existing pluggable auth system. Users register and log in with email/password. Registration is gated by an optional invite code (env var). Sessions reuse the existing `share_auth_sessions` table.
+
+## Architecture
+
+A new `LocalAuthStrategy` class in `server/auth/local.ts` implementing the existing `AuthStrategy` interface. A new `local_users` table in SQLite stores credentials. Server-rendered HTML forms handle login and registration (no SPA/JS needed). One new line in the factory switch in `server/auth/index.ts`.
+
+## Database
+
+New `local_users` table:
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT |
+| `email` | TEXT | NOT NULL, UNIQUE (case-insensitive via collation) |
+| `password_hash` | TEXT | NOT NULL |
+| `name` | TEXT | |
+| `created_at` | TEXT | NOT NULL (ISO 8601) |
+
+Sessions are stored in the existing `share_auth_sessions` table with `provider = 'local'`. The `access_token` JSON blob stores `{ localUserId: number }`.
+
+## Password Hashing
+
+Node's built-in `crypto.scrypt` with a random 16-byte salt. Stored as `salt:hash` in the `password_hash` column. No external dependency needed. No password requirements enforced.
+
+## Registration Flow
+
+- `PROOF_LOCAL_INVITE_CODE` env var controls registration access.
+- When set: the registration form shows an "Invite Code" field and validates it on submit.
+- When unset: open registration, no invite code field shown.
+- `GET /auth/register` renders the registration form (email, password, name, invite code if required).
+- `POST /auth/register` validates input, checks invite code if required, checks email uniqueness, creates user, creates session, redirects to `return_to` (default `/`).
+- Error states: invalid invite code, email already taken, missing required fields. Errors shown inline on the form.
+
+## Login Flow
+
+- `GET /auth/login` renders the login form (email, password) with a link to the registration page.
+- `POST /auth/login` verifies credentials against `local_users`, creates session in `share_auth_sessions`, sets `proof_session` cookie, redirects to `return_to`.
+- Error states: invalid credentials. Generic "Invalid email or password" message (no user enumeration).
+- `GET /auth/logout` revokes session, clears cookie, redirects to `/auth/login`.
+
+## Form Styling
+
+Server-rendered HTML matching the existing dark theme (same palette as `forbidden-page.ts` and `share-web-routes.ts` `renderUnavailableHtml`): `#0f172a` background, `#334155` borders, `#f8fafc` headings, `#3b82f6` primary buttons.
+
+## Security
+
+- `return_to` parameter validated with `sanitizeReturnTo` (same as WorkOS strategy) to prevent open redirects.
+- Timing-safe password comparison via `crypto.timingSafeEqual`.
+- Generic error messages on login failure to prevent user enumeration.
+- Invite code comparison is constant-time.
+
+## Configuration
+
+| Env Var | Required | Description |
+|---------|----------|-------------|
+| `PROOF_AUTH_STRATEGY` | Yes | Set to `local` |
+| `PROOF_LOCAL_INVITE_CODE` | No | When set, registration requires this code. When unset, open registration. |
+
+## Files
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `server/auth/local.ts` | `LocalAuthStrategy` class: routes, user resolution, password hashing, form rendering |
+| Modify | `server/auth/index.ts` | Add `case 'local'` to factory switch |
+| Modify | `server/db.ts` | Add `local_users` table creation + `createLocalUser`, `getLocalUserByEmail` helpers |
+| Modify | `.env.example` | Document `PROOF_LOCAL_INVITE_CODE` |
+
+## What This Does NOT Include
+
+- Email verification
+- Password reset flow
+- Rate limiting on login attempts (can be added later)
+- Admin UI for user management
+- Password requirements

--- a/fly.toml
+++ b/fly.toml
@@ -14,6 +14,11 @@ primary_region = "iad"
   COLLAB_EMBEDDED_WS = "true"
   # Set PROOF_PUBLIC_BASE_URL via `fly secrets set` after first deploy
   # so share links, WebSocket URLs, and agent docs use the correct origin.
+  # Auth: set via `fly secrets set` when using WorkOS:
+  #   fly secrets set PROOF_AUTH_STRATEGY=workos
+  #   fly secrets set WORKOS_API_KEY=sk_...
+  #   fly secrets set WORKOS_CLIENT_ID=client_...
+  #   fly secrets set PROOF_ALLOWED_ORG_IDS=org_...
 
 [http_service]
   internal_port = 5555

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,47 @@
+# See https://fly.io/docs/reference/configuration/ for reference.
+
+app = "proof-sdk"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "5555"
+  NODE_ENV = "production"
+  DATABASE_PATH = "/data/proof-share.db"
+  PROOF_TRUST_PROXY_HEADERS = "true"
+  COLLAB_EMBEDDED_WS = "true"
+  # Set PROOF_PUBLIC_BASE_URL via `fly secrets set` after first deploy
+  # so share links, WebSocket URLs, and agent docs use the correct origin.
+
+[http_service]
+  internal_port = 5555
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+  max_machines_running = 1  # SQLite does not support multi-writer
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 250
+    soft_limit = 200
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[mounts]
+  source = "proof_data"
+  destination = "/data"
+
+[checks]
+  [checks.health]
+    type = "http"
+    port = 5555
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@milkdown/preset-gfm": "^7.5.0",
     "@milkdown/theme-nord": "^7.5.0",
     "@resvg/resvg-js": "^2.6.2",
+    "@workos-inc/node": "^8.12.1",
     "beautiful-mermaid": "^1.1.3",
     "better-sqlite3": "^12.6.2",
     "express": "^5.2.1",

--- a/server/agent-edit-v2.ts
+++ b/server/agent-edit-v2.ts
@@ -841,6 +841,29 @@ export async function applyAgentEditV2(
     };
   }
 
+  // When baseRevision is used with live collab clients, verify the live Yjs
+  // state hasn't diverged from the persisted DB row. baseRevision only
+  // validates against the DB revision counter, but the live doc may contain
+  // unpersisted browser edits. Applying operations against the wrong baseline
+  // causes a split-brain where the DB row is updated but the live session
+  // never sees the change, leaving the projection stuck in yjs_fallback.
+  if (!baseToken && baseRevision !== null && activeCollabClients > 0 && authoritativeBase.ok) {
+    const liveMarkdown = stripEphemeralCollabSpans(authoritativeBase.base.markdown);
+    const persistedMarkdown = stripEphemeralCollabSpans(doc.markdown ?? '');
+    if (liveMarkdown !== persistedMarkdown) {
+      const snapshot = await buildSnapshot(slug);
+      return {
+        status: 409,
+        body: {
+          success: false,
+          code: 'LIVE_STATE_DIVERGED',
+          error: 'Live document state has diverged from persisted revision; use baseToken for coherent edits while collab clients are connected',
+          ...(snapshot ? { snapshot } : {}),
+        },
+      };
+    }
+  }
+
   const parser = await getHeadlessMilkdownParser();
   const authoritativeMarkdown = stripEphemeralCollabSpans(authoritativeBase.base.markdown);
   const authoritativeMarks = authoritativeBase.base.marks as Record<string, unknown>;

--- a/server/auth/forbidden-page.ts
+++ b/server/auth/forbidden-page.ts
@@ -1,0 +1,87 @@
+/**
+ * Renders a styled "Forbidden" page for users who are authenticated
+ * but belong to an organization not allowed to access this instance.
+ */
+export function renderForbiddenPage(options: {
+  email: string;
+  organizationName: string | null;
+  loginUrl: string;
+  switchOrgUrl: string | null;
+}): string {
+  const { email, organizationName, loginUrl, switchOrgUrl } = options;
+
+  const switchOrgButton = switchOrgUrl
+    ? `<a href="${escapeAttr(switchOrgUrl)}" class="btn btn-secondary">Switch Organisation</a>`
+    : '';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Access Denied | Proof</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .card {
+      width: min(520px, 100%);
+      background: rgba(15, 23, 42, 0.92);
+      border: 1px solid #334155;
+      border-radius: 24px;
+      padding: 40px 32px;
+      box-shadow: 0 20px 50px rgba(15, 23, 42, 0.45);
+      text-align: center;
+    }
+    .icon { font-size: 48px; margin-bottom: 16px; }
+    h1 { font-size: 24px; font-weight: 600; color: #f8fafc; margin-bottom: 12px; }
+    .detail { font-size: 15px; line-height: 1.6; color: #94a3b8; margin-bottom: 28px; }
+    .detail strong { color: #cbd5e1; }
+    .actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+    .btn {
+      display: inline-flex; align-items: center; padding: 10px 20px;
+      border-radius: 10px; font-size: 14px; font-weight: 500;
+      text-decoration: none; transition: background 0.15s, border-color 0.15s;
+    }
+    .btn-primary { background: #3b82f6; color: #fff; border: 1px solid #3b82f6; }
+    .btn-primary:hover { background: #2563eb; border-color: #2563eb; }
+    .btn-secondary { background: transparent; color: #cbd5e1; border: 1px solid #475569; }
+    .btn-secondary:hover { background: rgba(71, 85, 105, 0.3); border-color: #64748b; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">&#128274;</div>
+    <h1>Forbidden</h1>
+    <p class="detail">
+      You are logged in as <strong>${escapeHtml(email)}</strong>${organizationName ? ` (${escapeHtml(organizationName)})` : ''}.
+      <br>Your organisation does not have access to this application.
+    </p>
+    <div class="actions">
+      <a href="${escapeAttr(loginUrl)}" class="btn btn-primary">Switch Account</a>
+      ${switchOrgButton}
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/'/g, '&#39;');
+}

--- a/server/auth/forbidden-page.ts
+++ b/server/auth/forbidden-page.ts
@@ -20,12 +20,16 @@ export function renderForbiddenPage(options: {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Access Denied | Proof</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260309p">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://api.fontshare.com/v2/css?f[]=switzer@1,2&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background: #0f172a;
-      color: #e2e8f0;
+      font-family: 'Switzer', 'Switzer Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #f5f3ec;
+      color: #26251e;
       min-height: 100vh;
       display: flex;
       align-items: center;
@@ -34,27 +38,33 @@ export function renderForbiddenPage(options: {
     }
     .card {
       width: min(520px, 100%);
-      background: rgba(15, 23, 42, 0.92);
-      border: 1px solid #334155;
-      border-radius: 24px;
+      background: #edeae0;
+      border: 1px solid rgba(38, 37, 30, 0.03);
+      border-radius: 4px;
       padding: 40px 32px;
-      box-shadow: 0 20px 50px rgba(15, 23, 42, 0.45);
       text-align: center;
     }
     .icon { font-size: 48px; margin-bottom: 16px; }
-    h1 { font-size: 24px; font-weight: 600; color: #f8fafc; margin-bottom: 12px; }
-    .detail { font-size: 15px; line-height: 1.6; color: #94a3b8; margin-bottom: 28px; }
-    .detail strong { color: #cbd5e1; }
+    h1 { font-size: 26px; font-weight: 400; color: #26251e; margin-bottom: 12px; letter-spacing: -0.325px; }
+    .detail { font-size: 16px; line-height: 1.6; color: rgba(38, 37, 30, 0.6); margin-bottom: 28px; }
+    .detail strong { color: #26251e; }
     .actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
     .btn {
-      display: inline-flex; align-items: center; padding: 10px 20px;
-      border-radius: 10px; font-size: 14px; font-weight: 500;
-      text-decoration: none; transition: background 0.15s, border-color 0.15s;
+      display: inline-flex; align-items: center; padding: 12.48px 21.6px;
+      border-radius: 33554400px; font-family: inherit; font-size: 16px; font-weight: 400;
+      text-decoration: none;
+      transition: filter 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
     }
-    .btn-primary { background: #3b82f6; color: #fff; border: 1px solid #3b82f6; }
-    .btn-primary:hover { background: #2563eb; border-color: #2563eb; }
-    .btn-secondary { background: transparent; color: #cbd5e1; border: 1px solid #475569; }
-    .btn-secondary:hover { background: rgba(71, 85, 105, 0.3); border-color: #64748b; }
+    .btn-primary {
+      background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
+      color: #f7f7f4; border: none;
+    }
+    .btn-primary:hover { filter: brightness(1.1); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(38, 104, 84, 0.3); }
+    .btn-secondary {
+      background: transparent; color: #26251e;
+      border: 1px solid rgba(38, 37, 30, 0.12);
+    }
+    .btn-secondary:hover { background: rgba(38, 37, 30, 0.04); }
   </style>
 </head>
 <body>

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -1,6 +1,7 @@
 import type { AuthStrategy } from './strategy.js';
 import { NoneAuthStrategy } from './none.js';
 import { WorkOSAuthStrategy } from './workos.js';
+import { LocalAuthStrategy } from './local.js';
 
 export type { AuthStrategy, AuthenticatedUser } from './strategy.js';
 
@@ -8,7 +9,7 @@ let activeStrategy: AuthStrategy | null = null;
 
 /**
  * Returns the active auth strategy, creating it on first call.
- * Reads PROOF_AUTH_STRATEGY env var: 'none' (default) or 'workos'.
+ * Reads PROOF_AUTH_STRATEGY env var: 'none' (default), 'workos', or 'local'.
  */
 export function getAuthStrategy(): AuthStrategy {
   if (activeStrategy) return activeStrategy;
@@ -20,13 +21,17 @@ export function getAuthStrategy(): AuthStrategy {
       activeStrategy = new WorkOSAuthStrategy();
       console.log('[auth] strategy: workos');
       break;
+    case 'local':
+      activeStrategy = new LocalAuthStrategy();
+      console.log('[auth] strategy: local');
+      break;
     case 'none':
       activeStrategy = new NoneAuthStrategy();
       console.log('[auth] strategy: none (no authentication)');
       break;
     default:
       throw new Error(
-        `Unknown auth strategy: "${strategyName}". Valid values: none, workos`,
+        `Unknown auth strategy: "${strategyName}". Valid values: none, workos, local`,
       );
   }
 

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -1,0 +1,34 @@
+import type { AuthStrategy } from './strategy.js';
+import { NoneAuthStrategy } from './none.js';
+import { WorkOSAuthStrategy } from './workos.js';
+
+export type { AuthStrategy, AuthenticatedUser } from './strategy.js';
+
+let activeStrategy: AuthStrategy | null = null;
+
+/**
+ * Returns the active auth strategy, creating it on first call.
+ * Reads PROOF_AUTH_STRATEGY env var: 'none' (default) or 'workos'.
+ */
+export function getAuthStrategy(): AuthStrategy {
+  if (activeStrategy) return activeStrategy;
+
+  const strategyName = (process.env.PROOF_AUTH_STRATEGY || 'none').trim().toLowerCase();
+
+  switch (strategyName) {
+    case 'workos':
+      activeStrategy = new WorkOSAuthStrategy();
+      console.log('[auth] strategy: workos');
+      break;
+    case 'none':
+      activeStrategy = new NoneAuthStrategy();
+      console.log('[auth] strategy: none (no authentication)');
+      break;
+    default:
+      throw new Error(
+        `Unknown auth strategy: "${strategyName}". Valid values: none, workos`,
+      );
+  }
+
+  return activeStrategy;
+}

--- a/server/auth/local.ts
+++ b/server/auth/local.ts
@@ -74,7 +74,7 @@ function formPage(options: {
   title: string;
   error?: string | null;
   fields: string;
-  submitLabel: string;
+  submitLabel?: string;
   footerHtml?: string;
   action: string;
   returnTo: string;
@@ -140,7 +140,7 @@ function formPage(options: {
     <form method="POST" action="${escapeAttr(action)}">
       <input type="hidden" name="return_to" value="${escapeAttr(returnTo)}">
       ${fields}
-      <button type="submit" class="btn">${escapeHtml(submitLabel)}</button>
+      ${submitLabel ? `<button type="submit" class="btn">${escapeHtml(submitLabel)}</button>` : ''}
     </form>
     ${footerHtml ? `<div class="footer">${footerHtml}</div>` : ''}
   </div>
@@ -378,11 +378,11 @@ export class LocalAuthStrategy implements AuthStrategy {
         title: 'Account',
         action: '/auth/account/name',
         returnTo: '/',
-        submitLabel: 'Update Name',
         fields: `
           ${o.nameMsg ? successBanner(o.nameMsg) : ''}
           <label for="name">Name</label>
           <input type="text" id="name" name="name" value="${escapeAttr(user.name || '')}">
+          <button type="submit" class="btn" style="margin-bottom:0;">Update Name</button>
         </form>
         ${sectionDivider}
         <form method="POST" action="/auth/account/email">

--- a/server/auth/local.ts
+++ b/server/auth/local.ts
@@ -85,39 +85,46 @@ function formPage(options: {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${escapeHtml(title)} | Proof</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260309p">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://api.fontshare.com/v2/css?f[]=switzer@1,2&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background: #0f172a; color: #e2e8f0;
+      font-family: 'Switzer', 'Switzer Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #f5f3ec; color: #26251e;
       min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px;
     }
     .card {
-      width: min(420px, 100%); background: rgba(15, 23, 42, 0.92);
-      border: 1px solid #334155; border-radius: 24px;
-      padding: 40px 32px; box-shadow: 0 20px 50px rgba(15, 23, 42, 0.45);
+      width: min(420px, 100%); background: #edeae0;
+      border: 1px solid rgba(38, 37, 30, 0.03); border-radius: 4px;
+      padding: 40px 32px; position: relative;
     }
-    h1 { font-size: 24px; font-weight: 600; color: #f8fafc; margin-bottom: 24px; text-align: center; }
+    h1 { font-size: 26px; font-weight: 400; color: #26251e; margin-bottom: 24px; text-align: center; letter-spacing: -0.325px; }
     .error {
-      background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3);
-      color: #fca5a5; border-radius: 10px; padding: 10px 14px;
+      background: rgba(220, 38, 38, 0.08); border: 1px solid rgba(220, 38, 38, 0.15);
+      color: #991b1b; border-radius: 4px; padding: 10px 14px;
       font-size: 14px; margin-bottom: 20px; text-align: center;
     }
-    label { display: block; font-size: 13px; font-weight: 500; color: #94a3b8; margin-bottom: 6px; }
+    label { display: block; font-size: 14px; font-weight: 400; color: rgba(38, 37, 30, 0.6); margin-bottom: 6px; }
     input[type="text"], input[type="email"], input[type="password"] {
-      width: 100%; padding: 10px 14px; border-radius: 10px;
-      border: 1px solid #334155; background: #1e293b; color: #f8fafc;
-      font-size: 15px; margin-bottom: 16px; outline: none; transition: border-color 0.15s;
+      width: 100%; padding: 10px 14px; border-radius: 4px;
+      border: 1px solid rgba(38, 37, 30, 0.12); background: #f5f3ec; color: #26251e;
+      font-family: inherit; font-size: 15px; margin-bottom: 16px; outline: none; transition: border-color 0.15s;
     }
-    input:focus { border-color: #3b82f6; }
+    input:focus { border-color: #266854; }
     .btn {
-      width: 100%; padding: 12px; border-radius: 10px; border: none;
-      background: #3b82f6; color: #fff; font-size: 15px; font-weight: 500;
-      cursor: pointer; transition: background 0.15s; margin-top: 4px;
+      width: 100%; padding: 12.48px; border-radius: 33554400px; border: none;
+      background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
+      color: #f7f7f4; font-family: inherit; font-size: 16px; font-weight: 400;
+      cursor: pointer; margin-top: 4px;
+      transition: filter 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
     }
-    .btn:hover { background: #2563eb; }
-    .footer { text-align: center; margin-top: 20px; font-size: 14px; color: #64748b; }
-    .footer a { color: #3b82f6; text-decoration: none; }
+    .btn:hover { filter: brightness(1.1); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(38, 104, 84, 0.3); }
+    .btn:active { transform: translateY(1px); }
+    .footer { text-align: center; margin-top: 20px; font-size: 14px; color: rgba(38, 37, 30, 0.6); }
+    .footer a { color: #14a378; font-weight: 600; text-decoration: none; }
     .footer a:hover { text-decoration: underline; }
   </style>
 </head>

--- a/server/auth/local.ts
+++ b/server/auth/local.ts
@@ -1,0 +1,352 @@
+import { randomBytes, scrypt, timingSafeEqual } from 'crypto';
+import { randomUUID } from 'crypto';
+import { Router, urlencoded, type Request, type Response } from 'express';
+import type { AuthStrategy, AuthenticatedUser } from './strategy.js';
+import { getSessionCookie, setSessionCookie, clearSessionCookie } from '../cookies.js';
+import {
+  createShareAuthSession,
+  getShareAuthSession,
+  revokeShareAuthSession,
+  createLocalUser,
+  getLocalUserByEmail,
+} from '../db.js';
+
+// ── Password hashing ─────────────────────────────────────────────────────────
+
+function hashPassword(password: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const salt = randomBytes(16).toString('hex');
+    scrypt(password, salt, 64, (err, derived) => {
+      if (err) reject(err);
+      else resolve(`${salt}:${derived.toString('hex')}`);
+    });
+  });
+}
+
+function verifyPassword(password: string, stored: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const [salt, hash] = stored.split(':');
+    if (!salt || !hash) { resolve(false); return; }
+    scrypt(password, salt, 64, (err, derived) => {
+      if (err) reject(err);
+      else resolve(timingSafeEqual(Buffer.from(hash, 'hex'), derived));
+    });
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function sanitizeReturnTo(value: string): string {
+  if (value.startsWith('/') && !value.startsWith('//')) return value;
+  return '/';
+}
+
+function getInviteCode(): string | null {
+  const code = (process.env.PROOF_LOCAL_INVITE_CODE || '').trim();
+  return code || null;
+}
+
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+// ── HTML helpers ─────────────────────────────────────────────────────────────
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/'/g, '&#39;');
+}
+
+function formPage(options: {
+  title: string;
+  error?: string | null;
+  fields: string;
+  submitLabel: string;
+  footerHtml?: string;
+  action: string;
+  returnTo: string;
+}): string {
+  const { title, error, fields, submitLabel, footerHtml, action, returnTo } = options;
+  const errorBlock = error
+    ? `<div class="error">${escapeHtml(error)}</div>`
+    : '';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)} | Proof</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0f172a; color: #e2e8f0;
+      min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px;
+    }
+    .card {
+      width: min(420px, 100%); background: rgba(15, 23, 42, 0.92);
+      border: 1px solid #334155; border-radius: 24px;
+      padding: 40px 32px; box-shadow: 0 20px 50px rgba(15, 23, 42, 0.45);
+    }
+    h1 { font-size: 24px; font-weight: 600; color: #f8fafc; margin-bottom: 24px; text-align: center; }
+    .error {
+      background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3);
+      color: #fca5a5; border-radius: 10px; padding: 10px 14px;
+      font-size: 14px; margin-bottom: 20px; text-align: center;
+    }
+    label { display: block; font-size: 13px; font-weight: 500; color: #94a3b8; margin-bottom: 6px; }
+    input[type="text"], input[type="email"], input[type="password"] {
+      width: 100%; padding: 10px 14px; border-radius: 10px;
+      border: 1px solid #334155; background: #1e293b; color: #f8fafc;
+      font-size: 15px; margin-bottom: 16px; outline: none; transition: border-color 0.15s;
+    }
+    input:focus { border-color: #3b82f6; }
+    .btn {
+      width: 100%; padding: 12px; border-radius: 10px; border: none;
+      background: #3b82f6; color: #fff; font-size: 15px; font-weight: 500;
+      cursor: pointer; transition: background 0.15s; margin-top: 4px;
+    }
+    .btn:hover { background: #2563eb; }
+    .footer { text-align: center; margin-top: 20px; font-size: 14px; color: #64748b; }
+    .footer a { color: #3b82f6; text-decoration: none; }
+    .footer a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>${escapeHtml(title)}</h1>
+    ${errorBlock}
+    <form method="POST" action="${escapeAttr(action)}">
+      <input type="hidden" name="return_to" value="${escapeAttr(returnTo)}">
+      ${fields}
+      <button type="submit" class="btn">${escapeHtml(submitLabel)}</button>
+    </form>
+    ${footerHtml ? `<div class="footer">${footerHtml}</div>` : ''}
+  </div>
+</body>
+</html>`;
+}
+
+// ── Strategy ─────────────────────────────────────────────────────────────────
+
+export class LocalAuthStrategy implements AuthStrategy {
+  readonly name = 'local';
+  readonly router: Router;
+
+  constructor() {
+    this.router = this.buildRouter();
+  }
+
+  resolveUser(req: Request): AuthenticatedUser | null {
+    const sessionToken = getSessionCookie(req);
+    if (!sessionToken) return null;
+
+    const session = getShareAuthSession(sessionToken);
+    if (!session || session.revoked_at || session.provider !== 'local') return null;
+    if (new Date(session.session_expires_at) < new Date()) return null;
+
+    let data: { localUserId: number };
+    try {
+      data = JSON.parse(session.access_token);
+    } catch {
+      return null;
+    }
+
+    return {
+      id: String(data.localUserId),
+      email: session.email,
+      name: session.name,
+      organizationId: null,
+      organizationName: null,
+      sessionToken,
+    };
+  }
+
+  checkAccess(_user: AuthenticatedUser, _req: Request): string | null {
+    return null;
+  }
+
+  loginUrl(returnTo: string): string {
+    return `/auth/login?return_to=${encodeURIComponent(returnTo)}`;
+  }
+
+  logout(req: Request, res: Response): void {
+    const sessionToken = getSessionCookie(req);
+    if (sessionToken) revokeShareAuthSession(sessionToken);
+    clearSessionCookie(req, res);
+    res.redirect('/auth/login');
+  }
+
+  private createSession(userId: number, email: string, name: string | null, req: Request, res: Response): void {
+    const sessionToken = randomUUID();
+    const now = new Date();
+    const sessionExpiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    createShareAuthSession({
+      sessionToken,
+      provider: 'local',
+      everyUserId: 0,
+      email,
+      name,
+      accessToken: JSON.stringify({ localUserId: userId }),
+      accessExpiresAt: sessionExpiresAt.toISOString(),
+      sessionExpiresAt: sessionExpiresAt.toISOString(),
+    });
+
+    setSessionCookie(req, res, sessionToken);
+  }
+
+  private buildRouter(): Router {
+    const router = Router();
+    const parseForm = urlencoded({ extended: false });
+
+    // ── Login ────────────────────────────────────────────────────────────
+
+    router.get('/auth/login', (req: Request, res: Response) => {
+      const returnTo = sanitizeReturnTo(typeof req.query.return_to === 'string' ? req.query.return_to : '/');
+      const registerLink = `/auth/register${returnTo !== '/' ? `?return_to=${encodeURIComponent(returnTo)}` : ''}`;
+      res.type('html').send(formPage({
+        title: 'Sign In',
+        action: '/auth/login',
+        returnTo,
+        submitLabel: 'Sign In',
+        fields: `
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" required autofocus>
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required>`,
+        footerHtml: `Don't have an account? <a href="${escapeAttr(registerLink)}">Register</a>`,
+      }));
+    });
+
+    router.post('/auth/login', parseForm, async (req: Request, res: Response) => {
+      const email = typeof req.body?.email === 'string' ? req.body.email.trim() : '';
+      const password = typeof req.body?.password === 'string' ? req.body.password : '';
+      const returnTo = sanitizeReturnTo(typeof req.body?.return_to === 'string' ? req.body.return_to : '/');
+
+      if (!email || !password) {
+        res.status(400).type('html').send(formPage({
+          title: 'Sign In', action: '/auth/login', returnTo, submitLabel: 'Sign In',
+          error: 'Email and password are required.',
+          fields: `
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" value="${escapeAttr(email)}" required autofocus>
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required>`,
+          footerHtml: `Don't have an account? <a href="/auth/register">Register</a>`,
+        }));
+        return;
+      }
+
+      const user = getLocalUserByEmail(email);
+      const valid = user ? await verifyPassword(password, user.password_hash) : false;
+
+      if (!user || !valid) {
+        res.status(401).type('html').send(formPage({
+          title: 'Sign In', action: '/auth/login', returnTo, submitLabel: 'Sign In',
+          error: 'Invalid email or password.',
+          fields: `
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" value="${escapeAttr(email)}" required autofocus>
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required>`,
+          footerHtml: `Don't have an account? <a href="/auth/register">Register</a>`,
+        }));
+        return;
+      }
+
+      this.createSession(user.id, user.email, user.name, req, res);
+      res.redirect(returnTo);
+    });
+
+    // ── Register ─────────────────────────────────────────────────────────
+
+    router.get('/auth/register', (req: Request, res: Response) => {
+      const returnTo = sanitizeReturnTo(typeof req.query.return_to === 'string' ? req.query.return_to : '/');
+      const inviteRequired = getInviteCode() !== null;
+      const loginLink = `/auth/login${returnTo !== '/' ? `?return_to=${encodeURIComponent(returnTo)}` : ''}`;
+      res.type('html').send(formPage({
+        title: 'Register',
+        action: '/auth/register',
+        returnTo,
+        submitLabel: 'Create Account',
+        fields: `
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" required autofocus>
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required>
+          ${inviteRequired ? `<label for="invite_code">Invite Code</label>
+          <input type="text" id="invite_code" name="invite_code" required>` : ''}`,
+        footerHtml: `Already have an account? <a href="${escapeAttr(loginLink)}">Sign in</a>`,
+      }));
+    });
+
+    router.post('/auth/register', parseForm, async (req: Request, res: Response) => {
+      const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+      const email = typeof req.body?.email === 'string' ? req.body.email.trim() : '';
+      const password = typeof req.body?.password === 'string' ? req.body.password : '';
+      const inviteInput = typeof req.body?.invite_code === 'string' ? req.body.invite_code.trim() : '';
+      const returnTo = sanitizeReturnTo(typeof req.body?.return_to === 'string' ? req.body.return_to : '/');
+      const inviteRequired = getInviteCode();
+      const inviteRequiredBool = inviteRequired !== null;
+
+      const renderError = (error: string) => {
+        res.status(400).type('html').send(formPage({
+          title: 'Register', action: '/auth/register', returnTo, submitLabel: 'Create Account',
+          error,
+          fields: `
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" value="${escapeAttr(name)}">
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" value="${escapeAttr(email)}" required>
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required>
+            ${inviteRequiredBool ? `<label for="invite_code">Invite Code</label>
+            <input type="text" id="invite_code" name="invite_code" value="${escapeAttr(inviteInput)}" required>` : ''}`,
+          footerHtml: `Already have an account? <a href="/auth/login">Sign in</a>`,
+        }));
+      };
+
+      if (!email || !password) {
+        renderError('Email and password are required.');
+        return;
+      }
+
+      if (inviteRequired && !constantTimeCompare(inviteInput, inviteRequired)) {
+        renderError('Invalid invite code.');
+        return;
+      }
+
+      const existing = getLocalUserByEmail(email);
+      if (existing) {
+        renderError('An account with this email already exists.');
+        return;
+      }
+
+      const passwordHash = await hashPassword(password);
+      const user = createLocalUser({ email, passwordHash, name: name || null });
+
+      this.createSession(user.id, user.email, user.name, req, res);
+      res.redirect(returnTo);
+    });
+
+    // ── Logout ───────────────────────────────────────────────────────────
+
+    router.get('/auth/logout', (req: Request, res: Response) => {
+      this.logout(req, res);
+    });
+
+    return router;
+  }
+}

--- a/server/auth/local.ts
+++ b/server/auth/local.ts
@@ -9,6 +9,9 @@ import {
   revokeShareAuthSession,
   createLocalUser,
   getLocalUserByEmail,
+  getLocalUserById,
+  updateLocalUserName,
+  touchShareAuthSessionVerification,
 } from '../db.js';
 
 // ── Password hashing ─────────────────────────────────────────────────────────
@@ -346,6 +349,56 @@ export class LocalAuthStrategy implements AuthStrategy {
 
       this.createSession(user.id, user.email, user.name, req, res);
       res.redirect(returnTo);
+    });
+
+    // ── Account settings ──────────────────────────────────────────────────
+
+    router.get('/auth/account', (req: Request, res: Response) => {
+      const user = req.authenticatedUser;
+      if (!user) { res.redirect('/auth/login'); return; }
+      res.type('html').send(formPage({
+        title: 'Account',
+        action: '/auth/account',
+        returnTo: '/',
+        submitLabel: 'Save',
+        fields: `
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" value="${escapeAttr(user.name || '')}" autofocus>
+          <label>Email</label>
+          <input type="email" value="${escapeAttr(user.email)}" disabled style="opacity:0.6;cursor:not-allowed;">`,
+        footerHtml: '<a href="/">&larr; Back</a>',
+      }));
+    });
+
+    router.post('/auth/account', parseForm, (req: Request, res: Response) => {
+      const user = req.authenticatedUser;
+      if (!user) { res.redirect('/auth/login'); return; }
+
+      const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+      const userId = Number(user.id);
+
+      updateLocalUserName(userId, name || null);
+
+      // Update the session so the name change is reflected immediately
+      touchShareAuthSessionVerification({
+        sessionToken: user.sessionToken,
+        name: name || null,
+      });
+
+      res.type('html').send(formPage({
+        title: 'Account',
+        action: '/auth/account',
+        returnTo: '/',
+        submitLabel: 'Save',
+        error: null,
+        fields: `
+          <div style="background:rgba(38,104,84,0.08);border:1px solid rgba(38,104,84,0.15);color:#266854;border-radius:4px;padding:10px 14px;font-size:14px;margin-bottom:20px;text-align:center;">Name updated.</div>
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" value="${escapeAttr(name)}" autofocus>
+          <label>Email</label>
+          <input type="email" value="${escapeAttr(user.email)}" disabled style="opacity:0.6;cursor:not-allowed;">`,
+        footerHtml: '<a href="/">&larr; Back</a>',
+      }));
     });
 
     // ── Logout ───────────────────────────────────────────────────────────

--- a/server/auth/local.ts
+++ b/server/auth/local.ts
@@ -372,14 +372,14 @@ export class LocalAuthStrategy implements AuthStrategy {
 
     const sectionDivider = '<hr style="border:none;border-top:1px solid rgba(38,37,30,0.08);margin:24px 0;">';
 
-    const renderAccountPage = (user: AuthenticatedUser, opts?: { nameMsg?: string; emailMsg?: string; emailErr?: string; pwMsg?: string; pwErr?: string }) => {
+    const renderAccountPage = (user: AuthenticatedUser, opts?: { nameMsg?: string; nameErr?: string; emailMsg?: string; emailErr?: string; pwMsg?: string; pwErr?: string }) => {
       const o = opts ?? {};
       return formPage({
         title: 'Account',
         action: '/auth/account/name',
         returnTo: '/',
         fields: `
-          ${o.nameMsg ? successBanner(o.nameMsg) : ''}
+          ${o.nameMsg ? successBanner(o.nameMsg) : ''}${o.nameErr ? errorBanner(o.nameErr) : ''}
           <label for="name">Name</label>
           <input type="text" id="name" name="name" value="${escapeAttr(user.name || '')}">
           <button type="submit" class="btn" style="margin-bottom:0;">Update Name</button>
@@ -416,11 +416,14 @@ export class LocalAuthStrategy implements AuthStrategy {
       if (!user) return;
 
       const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
-      updateLocalUserName(Number(user.id), name || null);
-      touchShareAuthSessionVerification({ sessionToken: user.sessionToken, name: name || null });
+      if (!name) {
+        res.status(400).type('html').send(renderAccountPage(user, { nameErr: 'Name cannot be empty.' }));
+        return;
+      }
+      updateLocalUserName(Number(user.id), name);
+      touchShareAuthSessionVerification({ sessionToken: user.sessionToken, name });
 
-      // Reflect updated name in the rendered page
-      const updated = { ...user, name: name || null };
+      const updated = { ...user, name };
       res.type('html').send(renderAccountPage(updated, { nameMsg: 'Name updated.' }));
     });
 

--- a/server/auth/local.ts
+++ b/server/auth/local.ts
@@ -11,6 +11,8 @@ import {
   getLocalUserByEmail,
   getLocalUserById,
   updateLocalUserName,
+  updateLocalUserEmail,
+  updateLocalUserPassword,
   touchShareAuthSessionVerification,
 } from '../db.js';
 
@@ -353,52 +355,121 @@ export class LocalAuthStrategy implements AuthStrategy {
 
     // ── Account settings ──────────────────────────────────────────────────
 
+    const successBanner = (msg: string) =>
+      `<div style="background:rgba(38,104,84,0.08);border:1px solid rgba(38,104,84,0.15);color:#266854;border-radius:4px;padding:10px 14px;font-size:14px;margin-bottom:20px;text-align:center;">${escapeHtml(msg)}</div>`;
+
+    const errorBanner = (msg: string) =>
+      `<div class="error">${escapeHtml(msg)}</div>`;
+
+    const sectionDivider = '<hr style="border:none;border-top:1px solid rgba(38,37,30,0.08);margin:24px 0;">';
+
+    const renderAccountPage = (user: AuthenticatedUser, opts?: { nameMsg?: string; emailMsg?: string; emailErr?: string; pwMsg?: string; pwErr?: string }) => {
+      const o = opts ?? {};
+      return formPage({
+        title: 'Account',
+        action: '/auth/account/name',
+        returnTo: '/',
+        submitLabel: 'Update Name',
+        fields: `
+          ${o.nameMsg ? successBanner(o.nameMsg) : ''}
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" value="${escapeAttr(user.name || '')}">
+        </form>
+        ${sectionDivider}
+        <form method="POST" action="/auth/account/email">
+          ${o.emailMsg ? successBanner(o.emailMsg) : ''}${o.emailErr ? errorBanner(o.emailErr) : ''}
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" value="${escapeAttr(user.email)}" required>
+          <label for="email_password">Current Password</label>
+          <input type="password" id="email_password" name="password" required>
+          <button type="submit" class="btn" style="margin-bottom:0;">Update Email</button>
+        </form>
+        ${sectionDivider}
+        <form method="POST" action="/auth/account/password">
+          ${o.pwMsg ? successBanner(o.pwMsg) : ''}${o.pwErr ? errorBanner(o.pwErr) : ''}
+          <label for="current_password">Current Password</label>
+          <input type="password" id="current_password" name="current_password" required>
+          <label for="new_password">New Password</label>
+          <input type="password" id="new_password" name="new_password" required>
+          <button type="submit" class="btn" style="margin-bottom:0;">Update Password</button>`,
+        footerHtml: '<a href="/">&larr; Back</a>',
+      });
+    };
+
     router.get('/auth/account', (req: Request, res: Response) => {
       const user = req.authenticatedUser;
       if (!user) { res.redirect('/auth/login'); return; }
-      res.type('html').send(formPage({
-        title: 'Account',
-        action: '/auth/account',
-        returnTo: '/',
-        submitLabel: 'Save',
-        fields: `
-          <label for="name">Name</label>
-          <input type="text" id="name" name="name" value="${escapeAttr(user.name || '')}" autofocus>
-          <label>Email</label>
-          <input type="email" value="${escapeAttr(user.email)}" disabled style="opacity:0.6;cursor:not-allowed;">`,
-        footerHtml: '<a href="/">&larr; Back</a>',
-      }));
+      res.type('html').send(renderAccountPage(user));
     });
 
-    router.post('/auth/account', parseForm, (req: Request, res: Response) => {
+    router.post('/auth/account/name', parseForm, (req: Request, res: Response) => {
       const user = req.authenticatedUser;
       if (!user) { res.redirect('/auth/login'); return; }
 
       const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
-      const userId = Number(user.id);
+      updateLocalUserName(Number(user.id), name || null);
+      touchShareAuthSessionVerification({ sessionToken: user.sessionToken, name: name || null });
 
-      updateLocalUserName(userId, name || null);
+      // Reflect updated name in the rendered page
+      const updated = { ...user, name: name || null };
+      res.type('html').send(renderAccountPage(updated, { nameMsg: 'Name updated.' }));
+    });
 
-      // Update the session so the name change is reflected immediately
-      touchShareAuthSessionVerification({
-        sessionToken: user.sessionToken,
-        name: name || null,
-      });
+    router.post('/auth/account/email', parseForm, async (req: Request, res: Response) => {
+      const user = req.authenticatedUser;
+      if (!user) { res.redirect('/auth/login'); return; }
 
-      res.type('html').send(formPage({
-        title: 'Account',
-        action: '/auth/account',
-        returnTo: '/',
-        submitLabel: 'Save',
-        error: null,
-        fields: `
-          <div style="background:rgba(38,104,84,0.08);border:1px solid rgba(38,104,84,0.15);color:#266854;border-radius:4px;padding:10px 14px;font-size:14px;margin-bottom:20px;text-align:center;">Name updated.</div>
-          <label for="name">Name</label>
-          <input type="text" id="name" name="name" value="${escapeAttr(name)}" autofocus>
-          <label>Email</label>
-          <input type="email" value="${escapeAttr(user.email)}" disabled style="opacity:0.6;cursor:not-allowed;">`,
-        footerHtml: '<a href="/">&larr; Back</a>',
-      }));
+      const newEmail = typeof req.body?.email === 'string' ? req.body.email.trim() : '';
+      const password = typeof req.body?.password === 'string' ? req.body.password : '';
+
+      if (!newEmail || !password) {
+        res.status(400).type('html').send(renderAccountPage(user, { emailErr: 'Email and current password are required.' }));
+        return;
+      }
+
+      // Verify current password
+      const dbUser = getLocalUserById(Number(user.id));
+      if (!dbUser || !(await verifyPassword(password, dbUser.password_hash))) {
+        res.status(401).type('html').send(renderAccountPage(user, { emailErr: 'Incorrect password.' }));
+        return;
+      }
+
+      // Check uniqueness
+      const existing = getLocalUserByEmail(newEmail);
+      if (existing && existing.id !== dbUser.id) {
+        res.status(400).type('html').send(renderAccountPage(user, { emailErr: 'That email is already in use.' }));
+        return;
+      }
+
+      updateLocalUserEmail(dbUser.id, newEmail);
+      touchShareAuthSessionVerification({ sessionToken: user.sessionToken, email: newEmail });
+
+      const updated = { ...user, email: newEmail };
+      res.type('html').send(renderAccountPage(updated, { emailMsg: 'Email updated.' }));
+    });
+
+    router.post('/auth/account/password', parseForm, async (req: Request, res: Response) => {
+      const user = req.authenticatedUser;
+      if (!user) { res.redirect('/auth/login'); return; }
+
+      const currentPassword = typeof req.body?.current_password === 'string' ? req.body.current_password : '';
+      const newPassword = typeof req.body?.new_password === 'string' ? req.body.new_password : '';
+
+      if (!currentPassword || !newPassword) {
+        res.status(400).type('html').send(renderAccountPage(user, { pwErr: 'Both fields are required.' }));
+        return;
+      }
+
+      const dbUser = getLocalUserById(Number(user.id));
+      if (!dbUser || !(await verifyPassword(currentPassword, dbUser.password_hash))) {
+        res.status(401).type('html').send(renderAccountPage(user, { pwErr: 'Incorrect current password.' }));
+        return;
+      }
+
+      const newHash = await hashPassword(newPassword);
+      updateLocalUserPassword(dbUser.id, newHash);
+
+      res.type('html').send(renderAccountPage(user, { pwMsg: 'Password updated.' }));
     });
 
     // ── Logout ───────────────────────────────────────────────────────────

--- a/server/auth/local.ts
+++ b/server/auth/local.ts
@@ -355,6 +355,15 @@ export class LocalAuthStrategy implements AuthStrategy {
 
     // ── Account settings ──────────────────────────────────────────────────
 
+    // Account routes live on the strategy router (mounted before the auth
+    // middleware), so req.authenticatedUser is not set. Resolve the user
+    // directly from the session instead.
+    const requireUser = (req: Request, res: Response): AuthenticatedUser | null => {
+      const user = this.resolveUser(req) as AuthenticatedUser | null;
+      if (!user) res.redirect('/auth/login');
+      return user;
+    };
+
     const successBanner = (msg: string) =>
       `<div style="background:rgba(38,104,84,0.08);border:1px solid rgba(38,104,84,0.15);color:#266854;border-radius:4px;padding:10px 14px;font-size:14px;margin-bottom:20px;text-align:center;">${escapeHtml(msg)}</div>`;
 
@@ -397,14 +406,14 @@ export class LocalAuthStrategy implements AuthStrategy {
     };
 
     router.get('/auth/account', (req: Request, res: Response) => {
-      const user = req.authenticatedUser;
-      if (!user) { res.redirect('/auth/login'); return; }
+      const user = requireUser(req, res);
+      if (!user) return;
       res.type('html').send(renderAccountPage(user));
     });
 
     router.post('/auth/account/name', parseForm, (req: Request, res: Response) => {
-      const user = req.authenticatedUser;
-      if (!user) { res.redirect('/auth/login'); return; }
+      const user = requireUser(req, res);
+      if (!user) return;
 
       const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
       updateLocalUserName(Number(user.id), name || null);
@@ -416,8 +425,8 @@ export class LocalAuthStrategy implements AuthStrategy {
     });
 
     router.post('/auth/account/email', parseForm, async (req: Request, res: Response) => {
-      const user = req.authenticatedUser;
-      if (!user) { res.redirect('/auth/login'); return; }
+      const user = requireUser(req, res);
+      if (!user) return;
 
       const newEmail = typeof req.body?.email === 'string' ? req.body.email.trim() : '';
       const password = typeof req.body?.password === 'string' ? req.body.password : '';
@@ -449,8 +458,8 @@ export class LocalAuthStrategy implements AuthStrategy {
     });
 
     router.post('/auth/account/password', parseForm, async (req: Request, res: Response) => {
-      const user = req.authenticatedUser;
-      if (!user) { res.redirect('/auth/login'); return; }
+      const user = requireUser(req, res);
+      if (!user) return;
 
       const currentPassword = typeof req.body?.current_password === 'string' ? req.body.current_password : '';
       const newPassword = typeof req.body?.new_password === 'string' ? req.body.new_password : '';

--- a/server/auth/middleware.ts
+++ b/server/auth/middleware.ts
@@ -12,8 +12,11 @@ const PUBLIC_PATHS = new Set([
 
 /** Path prefixes that never require authentication. */
 const PUBLIC_PREFIXES = [
+  '/api/',           // API routes use their own auth (bearer tokens, share tokens)
+  '/documents/',     // Bridge/agent routes use x-bridge-token / x-share-token
   '/og/',            // OG image generation
   '/.well-known/',   // agent discovery
+  '/agent-docs',     // agent documentation
 ];
 
 function isPublicPath(pathname: string): boolean {

--- a/server/auth/middleware.ts
+++ b/server/auth/middleware.ts
@@ -1,0 +1,65 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { AuthStrategy } from './strategy.js';
+
+/** Routes that never require authentication. */
+const PUBLIC_PATHS = new Set([
+  '/health',
+  '/auth/login',
+  '/auth/callback',
+  '/auth/logout',
+]);
+
+/** Path prefixes that never require authentication. */
+const PUBLIC_PREFIXES = [
+  '/og/',            // OG image generation
+  '/.well-known/',   // agent discovery
+];
+
+function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_PATHS.has(pathname)) return true;
+  for (const prefix of PUBLIC_PREFIXES) {
+    if (pathname.startsWith(prefix)) return true;
+  }
+  // Static assets
+  if (/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)$/.test(pathname)) return true;
+  return false;
+}
+
+/**
+ * Creates an Express middleware that delegates authentication
+ * and authorization to the given strategy.
+ */
+export function createAuthMiddleware(strategy: AuthStrategy) {
+  // 'none' strategy — skip entirely, don't add overhead per-request
+  if (strategy.name === 'none') {
+    return (_req: Request, _res: Response, next: NextFunction) => next();
+  }
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    if (isPublicPath(req.path)) {
+      next();
+      return;
+    }
+
+    try {
+      const user = await strategy.resolveUser(req);
+
+      if (!user) {
+        res.redirect(strategy.loginUrl(req.originalUrl));
+        return;
+      }
+
+      const forbiddenHtml = strategy.checkAccess(user, req);
+      if (forbiddenHtml) {
+        res.status(403).type('html').send(forbiddenHtml);
+        return;
+      }
+
+      req.authenticatedUser = user;
+      next();
+    } catch (err) {
+      console.error('[auth] middleware error:', err);
+      res.redirect(strategy.loginUrl(req.originalUrl));
+    }
+  };
+}

--- a/server/auth/middleware.ts
+++ b/server/auth/middleware.ts
@@ -6,6 +6,7 @@ const PUBLIC_PATHS = new Set([
   '/health',
   '/auth/login',
   '/auth/callback',
+  '/api/auth/callback',
   '/auth/logout',
 ]);
 

--- a/server/auth/none.ts
+++ b/server/auth/none.ts
@@ -1,0 +1,27 @@
+import { Router, type Request, type Response } from 'express';
+import type { AuthStrategy, AuthenticatedUser } from './strategy.js';
+
+/**
+ * No-op auth strategy. All requests pass through unauthenticated.
+ * This is the default when PROOF_AUTH_STRATEGY is unset or 'none'.
+ */
+export class NoneAuthStrategy implements AuthStrategy {
+  readonly name = 'none';
+  readonly router = Router();
+
+  resolveUser(_req: Request): AuthenticatedUser | null {
+    return null;
+  }
+
+  checkAccess(_user: AuthenticatedUser, _req: Request): string | null {
+    return null;
+  }
+
+  loginUrl(_returnTo: string): string {
+    return '/';
+  }
+
+  logout(_req: Request, res: Response): void {
+    res.redirect('/');
+  }
+}

--- a/server/auth/strategy.ts
+++ b/server/auth/strategy.ts
@@ -1,0 +1,60 @@
+import type { Router, Request, Response } from 'express';
+
+export interface AuthenticatedUser {
+  /** Provider-specific user ID (e.g. WorkOS user ID). */
+  id: string;
+  email: string;
+  name: string | null;
+  /** Provider-specific organization ID, if applicable. */
+  organizationId: string | null;
+  /** Human-readable org name, if known. */
+  organizationName: string | null;
+  /** The raw session token (cookie value). */
+  sessionToken: string;
+}
+
+export interface AuthStrategy {
+  /** Strategy identifier (e.g. 'none', 'workos'). */
+  readonly name: string;
+
+  /**
+   * Express router with any routes the strategy needs
+   * (login, callback, logout, etc.). Mounted before the middleware.
+   */
+  readonly router: Router;
+
+  /**
+   * Resolve the authenticated user from the request (cookie, header, etc.).
+   * Return null if no valid session is present.
+   */
+  resolveUser(req: Request): Promise<AuthenticatedUser | null> | AuthenticatedUser | null;
+
+  /**
+   * After resolveUser succeeds, check whether this user is allowed
+   * to access the application (org gate, feature flags, etc.).
+   * Return null if access is granted, or an HTML string for a 403 page.
+   */
+  checkAccess(user: AuthenticatedUser, req: Request): string | null;
+
+  /**
+   * URL to redirect unauthenticated users to.
+   * @param returnTo - The URL the user was trying to reach.
+   */
+  loginUrl(returnTo: string): string;
+
+  /**
+   * Called on logout. Clear session state, cookies, etc.
+   */
+  logout(req: Request, res: Response): void;
+}
+
+/**
+ * Extend Express Request to carry the authenticated user.
+ */
+declare global {
+  namespace Express {
+    interface Request {
+      authenticatedUser?: AuthenticatedUser;
+    }
+  }
+}

--- a/server/auth/user-inject.ts
+++ b/server/auth/user-inject.ts
@@ -33,11 +33,13 @@ function buildAuthSnippet(name: string, email: string): string {
   font-family: 'Switzer','Switzer Variable',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
   font-size: 13px; color: #26251e;
 ">
-  <div style="
-    display: flex; align-items: center; gap: 8px;
+  <a href="/auth/account" style="
+    display: flex; align-items: center; gap: 8px; text-decoration: none; color: #26251e;
     background: #edeae0; border: 1px solid rgba(38,37,30,0.06);
     border-radius: 33554400px; padding: 5px 14px 5px 5px;
-  ">
+    transition: border-color 0.15s;
+  " onmouseover="this.style.borderColor='rgba(38,37,30,0.15)'"
+     onmouseout="this.style.borderColor='rgba(38,37,30,0.06)'">
     <div style="
       width: 26px; height: 26px; border-radius: 50%;
       background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
@@ -47,7 +49,7 @@ function buildAuthSnippet(name: string, email: string): string {
     <span style="max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
       ${escapeHtml(displayLabel)}
     </span>
-  </div>
+  </a>
   <a href="/auth/logout" style="
     color: rgba(38,37,30,0.4); font-size: 12px; text-decoration: none;
     padding: 4px 8px; border-radius: 33554400px;

--- a/server/auth/user-inject.ts
+++ b/server/auth/user-inject.ts
@@ -25,41 +25,84 @@ function buildAuthSnippet(name: string, email: string): string {
 <script>
 (function(){
   try { localStorage.setItem('proof-share-viewer-name', ${escapeJs(name || email)}); } catch(e){}
+
+  var displayLabel = ${escapeJs(displayLabel)};
+  var initial = ${escapeJs(initial)};
+  var injected = false;
+
+  function createUserFragment() {
+    var sep = document.createElement('span');
+    sep.className = 'share-pill-sep';
+    sep.style.cssText = 'width:1px;height:16px;background:rgba(0,0,0,0.08);flex-shrink:0;';
+
+    var avatar = document.createElement('div');
+    avatar.style.cssText = 'width:24px;height:24px;border-radius:50%;background:linear-gradient(-1.66deg,#266854 4.43%,#1f8a65 110.83%);color:#f7f7f4;font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;';
+    avatar.textContent = initial;
+
+    var nameSpan = document.createElement('span');
+    nameSpan.style.cssText = 'max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:13px;color:#374151;';
+    nameSpan.textContent = displayLabel;
+
+    var link = document.createElement('a');
+    link.href = '/auth/account';
+    link.style.cssText = 'display:flex;align-items:center;gap:7px;text-decoration:none;transition:opacity 0.15s;';
+    link.onmouseover = function(){ link.style.opacity='0.7'; };
+    link.onmouseout = function(){ link.style.opacity='1'; };
+    link.appendChild(avatar);
+    link.appendChild(nameSpan);
+
+    var logout = document.createElement('a');
+    logout.href = '/auth/logout';
+    logout.textContent = 'Sign out';
+    logout.style.cssText = 'color:rgba(55,65,81,0.5);font-size:12px;text-decoration:none;white-space:nowrap;transition:color 0.15s;';
+    logout.onmouseover = function(){ logout.style.color='#374151'; };
+    logout.onmouseout = function(){ logout.style.color='rgba(55,65,81,0.5)'; };
+
+    var frag = document.createDocumentFragment();
+    frag.appendChild(sep);
+    frag.appendChild(link);
+    frag.appendChild(logout);
+    return frag;
+  }
+
+  function injectInto(banner) {
+    if (injected) return;
+    if (banner.querySelector('[data-proof-auth]')) return;
+    var wrapper = document.createElement('div');
+    wrapper.setAttribute('data-proof-auth', '1');
+    wrapper.style.cssText = 'display:flex;align-items:center;gap:10px;margin-left:auto;padding-left:4px;';
+    wrapper.appendChild(createUserFragment());
+    banner.appendChild(wrapper);
+    injected = true;
+  }
+
+  function tryInject() {
+    var banner = document.getElementById('share-banner');
+    if (banner) { injectInto(banner); return true; }
+    return false;
+  }
+
+  // Try immediately, then observe for the banner being created.
+  if (!tryInject()) {
+    var obs = new MutationObserver(function() {
+      if (tryInject()) obs.disconnect();
+    });
+    obs.observe(document.body || document.documentElement, { childList: true, subtree: true });
+    // Give up after 30s to avoid leaking the observer.
+    setTimeout(function(){ obs.disconnect(); }, 30000);
+  }
+
+  // Also re-inject if the banner is recreated (e.g. on navigation).
+  var reObs = new MutationObserver(function() {
+    var banner = document.getElementById('share-banner');
+    if (banner && !banner.querySelector('[data-proof-auth]')) {
+      injected = false;
+      injectInto(banner);
+    }
+  });
+  reObs.observe(document.body || document.documentElement, { childList: true, subtree: true });
 })();
-</script>
-<div id="proof-auth-user" style="
-  position: fixed; top: 0; right: 12px; z-index: 1000;
-  display: flex; align-items: center; gap: 6px;
-  background: rgba(255,255,255,0.94);
-  backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(0,0,0,0.06); border-top: none;
-  border-radius: 0 0 28px 28px;
-  padding: 10px 14px 10px 10px;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.06), 0 0 0 0.5px rgba(0,0,0,0.03);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: 13px; color: #374151;
-">
-  <a href="/auth/account" style="
-    display: flex; align-items: center; gap: 7px; text-decoration: none; color: #374151;
-    transition: opacity 0.15s;
-  " onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'">
-    <div style="
-      width: 24px; height: 24px; border-radius: 50%;
-      background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
-      color: #f7f7f4; font-size: 11px; font-weight: 600;
-      display: flex; align-items: center; justify-content: center; flex-shrink: 0;
-    ">${escapeHtml(initial)}</div>
-    <span style="max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-      ${escapeHtml(displayLabel)}
-    </span>
-  </a>
-  <span style="color: rgba(0,0,0,0.12); font-size: 16px; font-weight: 300;">|</span>
-  <a href="/auth/logout" style="
-    color: rgba(55,65,81,0.5); font-size: 12px; text-decoration: none;
-    transition: color 0.15s;
-  " onmouseover="this.style.color='#374151'" onmouseout="this.style.color='rgba(55,65,81,0.5)'"
-  >Sign out</a>
-</div>`;
+</script>`;
 }
 
 /**

--- a/server/auth/user-inject.ts
+++ b/server/auth/user-inject.ts
@@ -1,0 +1,93 @@
+import type { Request, Response, NextFunction } from 'express';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeJs(value: string): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Builds a snippet to inject before </body> in HTML responses for authenticated users.
+ * - Sets the viewer name in localStorage so the editor name prompt is skipped.
+ * - Renders a small user pill in the top-right corner with name + logout link.
+ */
+function buildAuthSnippet(name: string, email: string): string {
+  const displayLabel = name || email;
+  const initial = (name || email).charAt(0).toUpperCase();
+
+  return `
+<script>
+(function(){
+  try { localStorage.setItem('proof-share-viewer-name', ${escapeJs(name || email)}); } catch(e){}
+})();
+</script>
+<div id="proof-auth-user" style="
+  position: fixed; top: 12px; right: 12px; z-index: 9999;
+  display: flex; align-items: center; gap: 8px;
+  font-family: 'Switzer','Switzer Variable',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  font-size: 13px; color: #26251e;
+">
+  <div style="
+    display: flex; align-items: center; gap: 8px;
+    background: #edeae0; border: 1px solid rgba(38,37,30,0.06);
+    border-radius: 33554400px; padding: 5px 14px 5px 5px;
+  ">
+    <div style="
+      width: 26px; height: 26px; border-radius: 50%;
+      background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
+      color: #f7f7f4; font-size: 12px; font-weight: 600;
+      display: flex; align-items: center; justify-content: center;
+    ">${escapeHtml(initial)}</div>
+    <span style="max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+      ${escapeHtml(displayLabel)}
+    </span>
+  </div>
+  <a href="/auth/logout" style="
+    color: rgba(38,37,30,0.4); font-size: 12px; text-decoration: none;
+    padding: 4px 8px; border-radius: 33554400px;
+    transition: color 0.15s, background 0.15s;
+  " onmouseover="this.style.color='#26251e';this.style.background='rgba(38,37,30,0.06)'"
+     onmouseout="this.style.color='rgba(38,37,30,0.4)';this.style.background='transparent'"
+  >Sign out</a>
+</div>`;
+}
+
+/**
+ * Middleware that injects authenticated user info into HTML responses.
+ * - Skips if no authenticated user on the request.
+ * - Intercepts res.send/res.end to inject the snippet before </body>.
+ */
+export function createUserInjectMiddleware() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const user = req.authenticatedUser;
+    if (!user) {
+      next();
+      return;
+    }
+
+    const snippet = buildAuthSnippet(user.name || '', user.email);
+
+    // Monkey-patch res.send to inject into HTML responses
+    const originalSend = res.send.bind(res);
+    res.send = function patchedSend(body?: unknown) {
+      const contentType = res.getHeader('content-type');
+      if (
+        typeof body === 'string'
+        && typeof contentType === 'string'
+        && contentType.includes('text/html')
+        && body.includes('</body>')
+      ) {
+        body = body.replace('</body>', `${snippet}\n</body>`);
+      }
+      return originalSend(body);
+    } as typeof res.send;
+
+    next();
+  };
+}

--- a/server/auth/user-inject.ts
+++ b/server/auth/user-inject.ts
@@ -28,34 +28,36 @@ function buildAuthSnippet(name: string, email: string): string {
 })();
 </script>
 <div id="proof-auth-user" style="
-  position: fixed; top: 12px; right: 12px; z-index: 9999;
-  display: flex; align-items: center; gap: 8px;
-  font-family: 'Switzer','Switzer Variable',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
-  font-size: 13px; color: #26251e;
+  position: fixed; top: 0; right: 12px; z-index: 1000;
+  display: flex; align-items: center; gap: 6px;
+  background: rgba(255,255,255,0.94);
+  backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(0,0,0,0.06); border-top: none;
+  border-radius: 0 0 28px 28px;
+  padding: 10px 14px 10px 10px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.06), 0 0 0 0.5px rgba(0,0,0,0.03);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 13px; color: #374151;
 ">
   <a href="/auth/account" style="
-    display: flex; align-items: center; gap: 8px; text-decoration: none; color: #26251e;
-    background: #edeae0; border: 1px solid rgba(38,37,30,0.06);
-    border-radius: 33554400px; padding: 5px 14px 5px 5px;
-    transition: border-color 0.15s;
-  " onmouseover="this.style.borderColor='rgba(38,37,30,0.15)'"
-     onmouseout="this.style.borderColor='rgba(38,37,30,0.06)'">
+    display: flex; align-items: center; gap: 7px; text-decoration: none; color: #374151;
+    transition: opacity 0.15s;
+  " onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'">
     <div style="
-      width: 26px; height: 26px; border-radius: 50%;
+      width: 24px; height: 24px; border-radius: 50%;
       background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
-      color: #f7f7f4; font-size: 12px; font-weight: 600;
-      display: flex; align-items: center; justify-content: center;
+      color: #f7f7f4; font-size: 11px; font-weight: 600;
+      display: flex; align-items: center; justify-content: center; flex-shrink: 0;
     ">${escapeHtml(initial)}</div>
-    <span style="max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+    <span style="max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
       ${escapeHtml(displayLabel)}
     </span>
   </a>
+  <span style="color: rgba(0,0,0,0.12); font-size: 16px; font-weight: 300;">|</span>
   <a href="/auth/logout" style="
-    color: rgba(38,37,30,0.4); font-size: 12px; text-decoration: none;
-    padding: 4px 8px; border-radius: 33554400px;
-    transition: color 0.15s, background 0.15s;
-  " onmouseover="this.style.color='#26251e';this.style.background='rgba(38,37,30,0.06)'"
-     onmouseout="this.style.color='rgba(38,37,30,0.4)';this.style.background='transparent'"
+    color: rgba(55,65,81,0.5); font-size: 12px; text-decoration: none;
+    transition: color 0.15s;
+  " onmouseover="this.style.color='#374151'" onmouseout="this.style.color='rgba(55,65,81,0.5)'"
   >Sign out</a>
 </div>`;
 }

--- a/server/auth/user-inject.ts
+++ b/server/auth/user-inject.ts
@@ -82,22 +82,78 @@ function buildAuthSnippet(name: string, email: string): string {
     return false;
   }
 
-  // Try immediately, then observe for the banner being created.
-  if (!tryInject()) {
-    var obs = new MutationObserver(function() {
-      if (tryInject()) obs.disconnect();
-    });
-    obs.observe(document.body || document.documentElement, { childList: true, subtree: true });
-    // Give up after 30s to avoid leaking the observer.
-    setTimeout(function(){ obs.disconnect(); }, 30000);
+  // Standalone fallback tab for pages without #share-banner (e.g. home page).
+  function showStandaloneTab() {
+    if (document.getElementById('proof-auth-user')) return;
+    var tab = document.createElement('div');
+    tab.id = 'proof-auth-user';
+    tab.style.cssText = 'position:fixed;top:0;right:12px;z-index:1000;display:flex;align-items:center;gap:6px;background:rgba(255,255,255,0.94);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border:1px solid rgba(0,0,0,0.06);border-top:none;border-radius:0 0 28px 28px;padding:10px 14px 10px 10px;box-shadow:0 6px 24px rgba(0,0,0,0.06),0 0 0 0.5px rgba(0,0,0,0.03);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;font-size:13px;color:#374151;';
+
+    var link = document.createElement('a');
+    link.href = '/auth/account';
+    link.style.cssText = 'display:flex;align-items:center;gap:7px;text-decoration:none;color:#374151;transition:opacity 0.15s;';
+    link.onmouseover = function(){ link.style.opacity='0.7'; };
+    link.onmouseout = function(){ link.style.opacity='1'; };
+    var av = document.createElement('div');
+    av.style.cssText = 'width:24px;height:24px;border-radius:50%;background:linear-gradient(-1.66deg,#266854 4.43%,#1f8a65 110.83%);color:#f7f7f4;font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0;';
+    av.textContent = initial;
+    var nm = document.createElement('span');
+    nm.style.cssText = 'max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+    nm.textContent = displayLabel;
+    link.appendChild(av);
+    link.appendChild(nm);
+
+    var pipe = document.createElement('span');
+    pipe.style.cssText = 'color:rgba(0,0,0,0.12);font-size:16px;font-weight:300;';
+    pipe.textContent = '|';
+
+    var lo = document.createElement('a');
+    lo.href = '/auth/logout';
+    lo.textContent = 'Sign out';
+    lo.style.cssText = 'color:rgba(55,65,81,0.5);font-size:12px;text-decoration:none;white-space:nowrap;transition:color 0.15s;';
+    lo.onmouseover = function(){ lo.style.color='#374151'; };
+    lo.onmouseout = function(){ lo.style.color='rgba(55,65,81,0.5)'; };
+
+    tab.appendChild(link);
+    tab.appendChild(pipe);
+    tab.appendChild(lo);
+    document.body.appendChild(tab);
   }
 
-  // Also re-inject if the banner is recreated (e.g. on navigation).
+  function removeStandaloneTab() {
+    var el = document.getElementById('proof-auth-user');
+    if (el) el.remove();
+  }
+
+  // Try to inject into #share-banner. If it doesn't appear within 1.5s,
+  // show the standalone tab instead.
+  var fallbackTimer = null;
+
+  if (!tryInject()) {
+    var obs = new MutationObserver(function() {
+      if (tryInject()) {
+        obs.disconnect();
+        clearTimeout(fallbackTimer);
+        removeStandaloneTab();
+      }
+    });
+    obs.observe(document.body || document.documentElement, { childList: true, subtree: true });
+
+    // Fallback: if no banner after 1.5s, show standalone tab.
+    fallbackTimer = setTimeout(function(){
+      obs.disconnect();
+      if (!injected) showStandaloneTab();
+    }, 1500);
+  }
+
+  // Re-inject if the banner is recreated (e.g. on navigation).
+  // Also remove the standalone tab if the banner appears later.
   var reObs = new MutationObserver(function() {
     var banner = document.getElementById('share-banner');
     if (banner && !banner.querySelector('[data-proof-auth]')) {
       injected = false;
       injectInto(banner);
+      removeStandaloneTab();
     }
   });
   reObs.observe(document.body || document.documentElement, { childList: true, subtree: true });

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from 'crypto';
+import { Router, type Request, type Response } from 'express';
+import { WorkOS } from '@workos-inc/node';
+import type { AuthStrategy, AuthenticatedUser } from './strategy.js';
+import { renderForbiddenPage } from './forbidden-page.js';
+import { getSessionCookie, setSessionCookie, clearSessionCookie } from '../cookies.js';
+import { createShareAuthSession, getShareAuthSession, revokeShareAuthSession } from '../db.js';
+
+// ── Config helpers ───────────────────────────────────────────────────────────
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required for WorkOS auth strategy`);
+  return value;
+}
+
+function getPublicBaseUrl(): string {
+  return requireEnv('PROOF_PUBLIC_BASE_URL').replace(/\/+$/, '');
+}
+
+function getAllowedOrgIds(): Set<string> {
+  const raw = (process.env.PROOF_ALLOWED_ORG_IDS || '').trim();
+  if (!raw) return new Set();
+  return new Set(raw.split(',').map((id) => id.trim()).filter(Boolean));
+}
+
+// ── WorkOS metadata stored in session ────────────────────────────────────────
+
+interface WorkOSSessionData {
+  workosUserId: string;
+  organizationId: string | null;
+  accessToken: string;
+  refreshToken: string | null;
+}
+
+function parseSessionData(accessTokenField: string): WorkOSSessionData | null {
+  try {
+    return JSON.parse(accessTokenField);
+  } catch {
+    return null;
+  }
+}
+
+// ── Strategy implementation ──────────────────────────────────────────────────
+
+export class WorkOSAuthStrategy implements AuthStrategy {
+  readonly name = 'workos';
+  readonly router: Router;
+
+  private readonly workos: WorkOS;
+  private readonly clientId: string;
+  private readonly redirectUri: string;
+  private readonly allowedOrgIds: Set<string>;
+
+  constructor() {
+    this.workos = new WorkOS(requireEnv('WORKOS_API_KEY'));
+    this.clientId = requireEnv('WORKOS_CLIENT_ID');
+    this.redirectUri = `${getPublicBaseUrl()}/auth/callback`;
+    this.allowedOrgIds = getAllowedOrgIds();
+    this.router = this.buildRouter();
+  }
+
+  // ── AuthStrategy interface ───────────────────────────────────────────────
+
+  resolveUser(req: Request): AuthenticatedUser | null {
+    const sessionToken = getSessionCookie(req);
+    if (!sessionToken) return null;
+
+    const session = getShareAuthSession(sessionToken);
+    if (!session || session.revoked_at || session.provider !== 'workos') return null;
+    if (new Date(session.session_expires_at) < new Date()) return null;
+
+    const data = parseSessionData(session.access_token);
+    if (!data) return null;
+
+    return {
+      id: data.workosUserId,
+      email: session.email,
+      name: session.name,
+      organizationId: data.organizationId,
+      organizationName: null, // Could be fetched from WorkOS API if needed
+      sessionToken,
+    };
+  }
+
+  checkAccess(user: AuthenticatedUser, req: Request): string | null {
+    if (this.allowedOrgIds.size === 0) return null; // No org restriction
+
+    if (!user.organizationId || !this.allowedOrgIds.has(user.organizationId)) {
+      const returnTo = encodeURIComponent(req.originalUrl);
+      return renderForbiddenPage({
+        email: user.email,
+        organizationName: user.organizationName,
+        loginUrl: '/auth/logout', // Switch Account = clear session, re-login
+        switchOrgUrl: `/auth/login?return_to=${returnTo}`, // Re-enter AuthKit to pick org
+      });
+    }
+
+    return null;
+  }
+
+  loginUrl(returnTo: string): string {
+    return `/auth/login?return_to=${encodeURIComponent(returnTo)}`;
+  }
+
+  logout(req: Request, res: Response): void {
+    const sessionToken = getSessionCookie(req);
+    if (sessionToken) revokeShareAuthSession(sessionToken);
+    clearSessionCookie(req, res);
+    res.redirect('/auth/login');
+  }
+
+  // ── Routes ───────────────────────────────────────────────────────────────
+
+  private buildRouter(): Router {
+    const router = Router();
+
+    /**
+     * GET /auth/login
+     * Redirects to WorkOS AuthKit.
+     * Query params:
+     *   - return_to: URL to redirect to after login (default: /)
+     *   - organization: pre-select an org in AuthKit (for "Switch Organisation")
+     *   - screen_hint: 'sign-up' | 'sign-in'
+     */
+    router.get('/auth/login', (req: Request, res: Response) => {
+      const returnTo = typeof req.query.return_to === 'string' ? req.query.return_to : '/';
+      const organizationId = typeof req.query.organization === 'string' ? req.query.organization : undefined;
+      const screenHint = typeof req.query.screen_hint === 'string' ? req.query.screen_hint : undefined;
+
+      const state = Buffer.from(JSON.stringify({ returnTo })).toString('base64url');
+
+      const authorizationUrl = this.workos.userManagement.getAuthorizationUrl({
+        provider: 'authkit',
+        clientId: this.clientId,
+        redirectUri: this.redirectUri,
+        state,
+        organizationId,
+        screenHint: screenHint as 'sign-up' | 'sign-in' | undefined,
+      });
+
+      res.redirect(authorizationUrl);
+    });
+
+    /**
+     * GET /auth/callback
+     * WorkOS redirects here after authentication.
+     */
+    router.get('/auth/callback', async (req: Request, res: Response) => {
+      const code = typeof req.query.code === 'string' ? req.query.code : '';
+      const stateParam = typeof req.query.state === 'string' ? req.query.state : '';
+      const error = typeof req.query.error === 'string' ? req.query.error : '';
+
+      if (error) {
+        console.error('[auth:workos] callback error:', error, req.query.error_description);
+        res.status(400).type('html').send(
+          `<!doctype html><html><body><h1>Sign-in failed</h1><p>${escapeHtml(error)}</p><p><a href="/auth/login">Try again</a></p></body></html>`,
+        );
+        return;
+      }
+
+      if (!code) {
+        res.status(400).type('html').send(
+          '<!doctype html><html><body><h1>Sign-in failed</h1><p>Missing authorization code.</p></body></html>',
+        );
+        return;
+      }
+
+      try {
+        const result = await this.workos.userManagement.authenticateWithCode({
+          clientId: this.clientId,
+          code,
+        });
+
+        const user = result.user;
+        const orgId = result.organizationId ?? null;
+
+        const sessionToken = randomUUID();
+        const now = new Date();
+        const sessionExpiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days
+        const accessExpiresAt = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour
+
+        const sessionData: WorkOSSessionData = {
+          workosUserId: user.id,
+          organizationId: orgId,
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+        };
+
+        createShareAuthSession({
+          sessionToken,
+          provider: 'workos',
+          everyUserId: 0, // Not used for WorkOS; real ID is in sessionData
+          email: user.email,
+          name: user.firstName
+            ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
+            : null,
+          accessToken: JSON.stringify(sessionData),
+          refreshToken: result.refreshToken,
+          accessExpiresAt: accessExpiresAt.toISOString(),
+          sessionExpiresAt: sessionExpiresAt.toISOString(),
+        });
+
+        setSessionCookie(req, res, sessionToken);
+
+        // Parse return_to from state
+        let returnTo = '/';
+        if (stateParam) {
+          try {
+            const parsed = JSON.parse(Buffer.from(stateParam, 'base64url').toString());
+            if (typeof parsed.returnTo === 'string') returnTo = parsed.returnTo;
+          } catch {
+            // ignore malformed state
+          }
+        }
+
+        res.redirect(returnTo);
+      } catch (err) {
+        console.error('[auth:workos] authentication failed:', err);
+        res.status(500).type('html').send(
+          '<!doctype html><html><body><h1>Sign-in failed</h1><p>Authentication error. Please try again.</p><p><a href="/auth/login">Try again</a></p></body></html>',
+        );
+      }
+    });
+
+    /**
+     * GET /auth/logout
+     */
+    router.get('/auth/logout', (req: Request, res: Response) => {
+      this.logout(req, res);
+    });
+
+    return router;
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -232,6 +232,58 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     });
 
     /**
+     * GET /auth/account — read-only profile page (WorkOS manages the actual profile)
+     */
+    router.get('/auth/account', (req: Request, res: Response) => {
+      const user = this.resolveUser(req) as AuthenticatedUser | null;
+      if (!user) { res.redirect('/auth/login'); return; }
+
+      res.type('html').send(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Account | Proof</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=20260309p">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://api.fontshare.com/v2/css?f[]=switzer@1,2&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Switzer','Switzer Variable',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+      background: #f5f3ec; color: #26251e;
+      min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px;
+    }
+    .card {
+      width: min(420px, 100%); background: #edeae0;
+      border: 1px solid rgba(38,37,30,0.03); border-radius: 4px; padding: 40px 32px;
+    }
+    h1 { font-size: 26px; font-weight: 400; color: #26251e; margin-bottom: 24px; text-align: center; letter-spacing: -0.325px; }
+    label { display: block; font-size: 14px; font-weight: 400; color: rgba(38,37,30,0.6); margin-bottom: 6px; }
+    .value { font-size: 15px; color: #26251e; margin-bottom: 16px; padding: 10px 14px; background: #f5f3ec; border: 1px solid rgba(38,37,30,0.08); border-radius: 4px; }
+    .hint { font-size: 13px; color: rgba(38,37,30,0.45); text-align: center; margin-bottom: 20px; }
+    .footer { text-align: center; margin-top: 20px; font-size: 14px; color: rgba(38,37,30,0.6); }
+    .footer a { color: #14a378; font-weight: 600; text-decoration: none; }
+    .footer a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Account</h1>
+    <label>Name</label>
+    <div class="value">${escapeHtml(user.name || '—')}</div>
+    <label>Email</label>
+    <div class="value">${escapeHtml(user.email)}</div>
+    ${user.organizationName ? `<label>Organisation</label><div class="value">${escapeHtml(user.organizationName)}</div>` : ''}
+    <p class="hint">Your account is managed by your organisation via WorkOS.</p>
+    <div class="footer"><a href="/">&larr; Back</a></div>
+  </div>
+</body>
+</html>`);
+    });
+
+    /**
      * GET /auth/logout
      */
     router.get('/auth/logout', (req: Request, res: Response) => {

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -115,24 +115,23 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     return `/auth/login?return_to=${encodeURIComponent(returnTo)}`;
   }
 
-  async logout(req: Request, res: Response): Promise<void> {
+  logout(req: Request, res: Response): void {
     const sessionToken = getSessionCookie(req);
     let workosLogoutUrl: string | null = null;
 
     if (sessionToken) {
-      // Try to get WorkOS logout URL to clear the AuthKit session too
       const session = getShareAuthSession(sessionToken);
       if (session) {
         const data = parseSessionData(session.access_token);
-        if (data?.sealedSession) {
+        // Extract the session ID from the JWT access token's `sid` claim
+        if (data?.accessToken) {
           try {
-            const workosSession = this.workos.userManagement.loadSealedSession({
-              sessionData: data.sealedSession,
-              cookiePassword: getCookiePassword(),
-            });
-            workosLogoutUrl = await workosSession.getLogoutUrl();
+            const payload = JSON.parse(Buffer.from(data.accessToken.split('.')[1], 'base64').toString());
+            if (payload.sid) {
+              workosLogoutUrl = this.workos.userManagement.getLogoutUrl({ sessionId: payload.sid });
+            }
           } catch {
-            // Sealed session may be expired/invalid — fall through to local logout
+            console.warn('[auth:workos] failed to extract sid from access token');
           }
         }
       }
@@ -140,7 +139,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     }
 
     clearSessionCookie(req, res);
-    res.redirect(workosLogoutUrl ?? '/auth/login');
+    res.redirect(workosLogoutUrl || '/auth/login');
   }
 
   // ── Routes ───────────────────────────────────────────────────────────────
@@ -333,8 +332,8 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     /**
      * GET /auth/logout
      */
-    router.get('/auth/logout', async (req: Request, res: Response) => {
-      await this.logout(req, res);
+    router.get('/auth/logout', (req: Request, res: Response) => {
+      this.logout(req, res);
     });
 
     return router;

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -63,7 +63,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
   constructor() {
     this.workos = new WorkOS(requireEnv('WORKOS_API_KEY'));
     this.clientId = requireEnv('WORKOS_CLIENT_ID');
-    this.redirectUri = `${getPublicBaseUrl()}/auth/callback`;
+    this.redirectUri = `${getPublicBaseUrl()}/api/auth/callback`;
     this.allowedOrgIds = getAllowedOrgIds();
     this.router = this.buildRouter();
   }
@@ -151,10 +151,10 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     });
 
     /**
-     * GET /auth/callback
+     * GET /api/auth/callback
      * WorkOS redirects here after authentication.
      */
-    router.get('/auth/callback', async (req: Request, res: Response) => {
+    router.get('/api/auth/callback', async (req: Request, res: Response) => {
       const code = typeof req.query.code === 'string' ? req.query.code : '';
       const stateParam = typeof req.query.state === 'string' ? req.query.state : '';
       const error = typeof req.query.error === 'string' ? req.query.error : '';

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -26,6 +26,10 @@ function getPublicBaseUrl(): string {
   return requireEnv('PROOF_PUBLIC_BASE_URL').replace(/\/+$/, '');
 }
 
+function getCookiePassword(): string {
+  return requireEnv('WORKOS_COOKIE_PASSWORD');
+}
+
 function getAllowedOrgIds(): Set<string> {
   const raw = (process.env.PROOF_ALLOWED_ORG_IDS || '').trim();
   if (!raw) return new Set();
@@ -39,6 +43,7 @@ interface WorkOSSessionData {
   organizationId: string | null;
   accessToken: string;
   refreshToken: string | null;
+  sealedSession: string | null;
 }
 
 function parseSessionData(accessTokenField: string): WorkOSSessionData | null {
@@ -99,8 +104,8 @@ export class WorkOSAuthStrategy implements AuthStrategy {
       return renderForbiddenPage({
         email: user.email,
         organizationName: user.organizationName,
-        loginUrl: '/auth/logout', // Switch Account = clear session, re-login
-        switchOrgUrl: `/auth/login?return_to=${returnTo}`, // Re-enter AuthKit to pick org
+        loginUrl: '/auth/logout', // Switch Account = clear both local + WorkOS session
+        switchOrgUrl: `/auth/login?return_to=${returnTo}&prompt=select_organization`, // Force org picker
       });
     }
 
@@ -111,11 +116,32 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     return `/auth/login?return_to=${encodeURIComponent(returnTo)}`;
   }
 
-  logout(req: Request, res: Response): void {
+  async logout(req: Request, res: Response): Promise<void> {
     const sessionToken = getSessionCookie(req);
-    if (sessionToken) revokeShareAuthSession(sessionToken);
+    let workosLogoutUrl: string | null = null;
+
+    if (sessionToken) {
+      // Try to get WorkOS logout URL to clear the AuthKit session too
+      const session = getShareAuthSession(sessionToken);
+      if (session) {
+        const data = parseSessionData(session.access_token);
+        if (data?.sealedSession) {
+          try {
+            const workosSession = this.workos.userManagement.loadSealedSession({
+              sessionData: data.sealedSession,
+              cookiePassword: getCookiePassword(),
+            });
+            workosLogoutUrl = await workosSession.getLogoutUrl();
+          } catch {
+            // Sealed session may be expired/invalid — fall through to local logout
+          }
+        }
+      }
+      revokeShareAuthSession(sessionToken);
+    }
+
     clearSessionCookie(req, res);
-    res.redirect('/auth/login');
+    res.redirect(workosLogoutUrl ?? '/auth/login');
   }
 
   // ── Routes ───────────────────────────────────────────────────────────────
@@ -130,11 +156,13 @@ export class WorkOSAuthStrategy implements AuthStrategy {
      *   - return_to: URL to redirect to after login (default: /)
      *   - organization: pre-select an org in AuthKit (for "Switch Organisation")
      *   - screen_hint: 'sign-up' | 'sign-in'
+     *   - prompt: passed through to WorkOS (e.g. 'select_organization')
      */
     router.get('/auth/login', (req: Request, res: Response) => {
       const returnTo = sanitizeReturnTo(typeof req.query.return_to === 'string' ? req.query.return_to : '/');
       const organizationId = typeof req.query.organization === 'string' ? req.query.organization : undefined;
       const screenHint = typeof req.query.screen_hint === 'string' ? req.query.screen_hint : undefined;
+      const prompt = typeof req.query.prompt === 'string' ? req.query.prompt : undefined;
 
       const state = Buffer.from(JSON.stringify({ returnTo })).toString('base64url');
 
@@ -145,6 +173,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
         state,
         organizationId,
         screenHint: screenHint as 'sign-up' | 'sign-in' | undefined,
+        prompt,
       });
 
       res.redirect(authorizationUrl);
@@ -175,9 +204,11 @@ export class WorkOSAuthStrategy implements AuthStrategy {
       }
 
       try {
+        const cookiePassword = getCookiePassword();
         const result = await this.workos.userManagement.authenticateWithCode({
           clientId: this.clientId,
           code,
+          session: { sealSession: true, cookiePassword },
         });
 
         const user = result.user;
@@ -193,6 +224,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
           organizationId: orgId,
           accessToken: result.accessToken,
           refreshToken: result.refreshToken,
+          sealedSession: result.sealedSession ?? null,
         };
 
         createShareAuthSession({
@@ -286,8 +318,8 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     /**
      * GET /auth/logout
      */
-    router.get('/auth/logout', (req: Request, res: Response) => {
-      this.logout(req, res);
+    router.get('/auth/logout', async (req: Request, res: Response) => {
+      await this.logout(req, res);
     });
 
     return router;

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -281,7 +281,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
                 const isCurrent = m.organizationId === user.organizationId;
                 return `<a href="/auth/login?organization=${escapeAttr(m.organizationId)}&return_to=%2F" style="
                   display:flex;align-items:center;justify-content:space-between;
-                  padding:10px 14px;background:${isCurrent ? '#f5f3ec' : '#f5f3ec'};
+                  padding:10px 14px;background:${isCurrent ? '#edeae0' : '#f5f3ec'};
                   border:1px solid ${isCurrent ? '#266854' : 'rgba(38,37,30,0.08)'};
                   border-radius:4px;text-decoration:none;color:#26251e;font-size:15px;
                   transition:border-color 0.15s;

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -295,6 +295,21 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     label { display: block; font-size: 14px; font-weight: 400; color: rgba(38,37,30,0.6); margin-bottom: 6px; }
     .value { font-size: 15px; color: #26251e; margin-bottom: 16px; padding: 10px 14px; background: #f5f3ec; border: 1px solid rgba(38,37,30,0.08); border-radius: 4px; }
     .hint { font-size: 13px; color: rgba(38,37,30,0.45); text-align: center; margin-bottom: 20px; }
+    .actions { display: flex; gap: 10px; margin-top: 24px; }
+    .btn {
+      flex: 1; display: inline-flex; align-items: center; justify-content: center;
+      padding: 12.48px 21.6px; border-radius: 33554400px;
+      font-family: inherit; font-size: 15px; font-weight: 400;
+      text-decoration: none; text-align: center;
+      transition: filter 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
+    }
+    .btn-primary {
+      background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
+      color: #f7f7f4; border: none;
+    }
+    .btn-primary:hover { filter: brightness(1.1); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(38,104,84,0.3); }
+    .btn-secondary { background: transparent; color: #26251e; border: 1px solid rgba(38,37,30,0.12); }
+    .btn-secondary:hover { background: rgba(38,37,30,0.04); }
     .footer { text-align: center; margin-top: 20px; font-size: 14px; color: rgba(38,37,30,0.6); }
     .footer a { color: #14a378; font-weight: 600; text-decoration: none; }
     .footer a:hover { text-decoration: underline; }
@@ -309,6 +324,10 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     <div class="value">${escapeHtml(user.email)}</div>
     ${user.organizationName ? `<label>Organisation</label><div class="value">${escapeHtml(user.organizationName)}</div>` : ''}
     <p class="hint">Your account is managed by your organisation via WorkOS.</p>
+    <div class="actions">
+      <a href="/auth/login?prompt=select_organization&return_to=%2F" class="btn btn-secondary">Switch Organisation</a>
+      <a href="/auth/logout" class="btn btn-secondary">Sign out</a>
+    </div>
     <div class="footer"><a href="/">&larr; Back</a></div>
   </div>
 </body>

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -103,8 +103,8 @@ export class WorkOSAuthStrategy implements AuthStrategy {
       return renderForbiddenPage({
         email: user.email,
         organizationName: user.organizationName,
-        loginUrl: '/auth/logout', // Switch Account = clear both local + WorkOS session
-        switchOrgUrl: '/auth/logout', // Also full logout — WorkOS will show org picker on re-login if user has multiple orgs
+        loginUrl: '/auth/logout',
+        switchOrgUrl: '/auth/account', // Account page shows org list for switching
       });
     }
 
@@ -259,11 +259,40 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     });
 
     /**
-     * GET /auth/account — read-only profile page (WorkOS manages the actual profile)
+     * GET /auth/account — profile page with org switcher
      */
-    router.get('/auth/account', (req: Request, res: Response) => {
+    router.get('/auth/account', async (req: Request, res: Response) => {
       const user = this.resolveUser(req) as AuthenticatedUser | null;
       if (!user) { res.redirect('/auth/login'); return; }
+
+      // Fetch the user's org memberships so they can switch
+      let orgButtons = '';
+      try {
+        const memberships = await this.workos.userManagement.listOrganizationMemberships({
+          userId: user.id,
+          statuses: ['active'],
+        });
+        const orgs = memberships.data || [];
+        if (orgs.length > 1) {
+          orgButtons = `
+            <label>Switch Organisation</label>
+            <div style="display:flex;flex-direction:column;gap:8px;margin-bottom:16px;">
+              ${orgs.map((m) => {
+                const isCurrent = m.organizationId === user.organizationId;
+                return `<a href="/auth/login?organization=${escapeAttr(m.organizationId)}&return_to=%2F" style="
+                  display:flex;align-items:center;justify-content:space-between;
+                  padding:10px 14px;background:${isCurrent ? '#f5f3ec' : '#f5f3ec'};
+                  border:1px solid ${isCurrent ? '#266854' : 'rgba(38,37,30,0.08)'};
+                  border-radius:4px;text-decoration:none;color:#26251e;font-size:15px;
+                  transition:border-color 0.15s;
+                " onmouseover="this.style.borderColor='#266854'" onmouseout="this.style.borderColor='${isCurrent ? '#266854' : 'rgba(38,37,30,0.08)'}'"
+                >${escapeHtml(m.organizationName)}${isCurrent ? '<span style="font-size:12px;color:#266854;font-weight:500;">Current</span>' : ''}</a>`;
+              }).join('')}
+            </div>`;
+        }
+      } catch (err) {
+        console.warn('[auth:workos] failed to list org memberships:', err);
+      }
 
       res.type('html').send(`<!doctype html>
 <html lang="en">
@@ -290,24 +319,11 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     label { display: block; font-size: 14px; font-weight: 400; color: rgba(38,37,30,0.6); margin-bottom: 6px; }
     .value { font-size: 15px; color: #26251e; margin-bottom: 16px; padding: 10px 14px; background: #f5f3ec; border: 1px solid rgba(38,37,30,0.08); border-radius: 4px; }
     .hint { font-size: 13px; color: rgba(38,37,30,0.45); text-align: center; margin-bottom: 20px; }
-    .actions { display: flex; gap: 10px; margin-top: 24px; }
-    .btn {
-      flex: 1; display: inline-flex; align-items: center; justify-content: center;
-      padding: 12.48px 21.6px; border-radius: 33554400px;
-      font-family: inherit; font-size: 15px; font-weight: 400;
-      text-decoration: none; text-align: center;
-      transition: filter 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
-    }
-    .btn-primary {
-      background: linear-gradient(-1.66deg, #266854 4.43%, #1f8a65 110.83%);
-      color: #f7f7f4; border: none;
-    }
-    .btn-primary:hover { filter: brightness(1.1); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(38,104,84,0.3); }
-    .btn-secondary { background: transparent; color: #26251e; border: 1px solid rgba(38,37,30,0.12); }
-    .btn-secondary:hover { background: rgba(38,37,30,0.04); }
     .footer { text-align: center; margin-top: 20px; font-size: 14px; color: rgba(38,37,30,0.6); }
     .footer a { color: #14a378; font-weight: 600; text-decoration: none; }
     .footer a:hover { text-decoration: underline; }
+    .sign-out { display:block; text-align:center; margin-top:24px; color:rgba(38,37,30,0.4); font-size:13px; text-decoration:none; transition:color 0.15s; }
+    .sign-out:hover { color:#26251e; }
   </style>
 </head>
 <body>
@@ -317,12 +333,9 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     <div class="value">${escapeHtml(user.name || '—')}</div>
     <label>Email</label>
     <div class="value">${escapeHtml(user.email)}</div>
-    ${user.organizationName ? `<label>Organisation</label><div class="value">${escapeHtml(user.organizationName)}</div>` : ''}
+    ${orgButtons}
     <p class="hint">Your account is managed by your organisation via WorkOS.</p>
-    <div class="actions">
-      <a href="/auth/logout" class="btn btn-secondary">Switch Organisation</a>
-      <a href="/auth/logout" class="btn btn-secondary">Sign out</a>
-    </div>
+    <a href="/auth/logout" class="sign-out">Sign out</a>
     <div class="footer"><a href="/">&larr; Back</a></div>
   </div>
 </body>
@@ -346,4 +359,8 @@ function escapeHtml(value: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/'/g, '&#39;');
 }

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -6,6 +6,14 @@ import { renderForbiddenPage } from './forbidden-page.js';
 import { getSessionCookie, setSessionCookie, clearSessionCookie } from '../cookies.js';
 import { createShareAuthSession, getShareAuthSession, revokeShareAuthSession } from '../db.js';
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Prevent open redirects: only allow relative paths. */
+function sanitizeReturnTo(value: string): string {
+  if (value.startsWith('/') && !value.startsWith('//')) return value;
+  return '/';
+}
+
 // ── Config helpers ───────────────────────────────────────────────────────────
 
 function requireEnv(name: string): string {
@@ -124,7 +132,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
      *   - screen_hint: 'sign-up' | 'sign-in'
      */
     router.get('/auth/login', (req: Request, res: Response) => {
-      const returnTo = typeof req.query.return_to === 'string' ? req.query.return_to : '/';
+      const returnTo = sanitizeReturnTo(typeof req.query.return_to === 'string' ? req.query.return_to : '/');
       const organizationId = typeof req.query.organization === 'string' ? req.query.organization : undefined;
       const screenHint = typeof req.query.screen_hint === 'string' ? req.query.screen_hint : undefined;
 
@@ -208,7 +216,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
         if (stateParam) {
           try {
             const parsed = JSON.parse(Buffer.from(stateParam, 'base64url').toString());
-            if (typeof parsed.returnTo === 'string') returnTo = parsed.returnTo;
+            if (typeof parsed.returnTo === 'string') returnTo = sanitizeReturnTo(parsed.returnTo);
           } catch {
             // ignore malformed state
           }

--- a/server/auth/workos.ts
+++ b/server/auth/workos.ts
@@ -100,12 +100,11 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     if (this.allowedOrgIds.size === 0) return null; // No org restriction
 
     if (!user.organizationId || !this.allowedOrgIds.has(user.organizationId)) {
-      const returnTo = encodeURIComponent(req.originalUrl);
       return renderForbiddenPage({
         email: user.email,
         organizationName: user.organizationName,
         loginUrl: '/auth/logout', // Switch Account = clear both local + WorkOS session
-        switchOrgUrl: `/auth/login?return_to=${returnTo}&prompt=select_organization`, // Force org picker
+        switchOrgUrl: '/auth/logout', // Also full logout — WorkOS will show org picker on re-login if user has multiple orgs
       });
     }
 
@@ -156,13 +155,11 @@ export class WorkOSAuthStrategy implements AuthStrategy {
      *   - return_to: URL to redirect to after login (default: /)
      *   - organization: pre-select an org in AuthKit (for "Switch Organisation")
      *   - screen_hint: 'sign-up' | 'sign-in'
-     *   - prompt: passed through to WorkOS (e.g. 'select_organization')
      */
     router.get('/auth/login', (req: Request, res: Response) => {
       const returnTo = sanitizeReturnTo(typeof req.query.return_to === 'string' ? req.query.return_to : '/');
       const organizationId = typeof req.query.organization === 'string' ? req.query.organization : undefined;
       const screenHint = typeof req.query.screen_hint === 'string' ? req.query.screen_hint : undefined;
-      const prompt = typeof req.query.prompt === 'string' ? req.query.prompt : undefined;
 
       const state = Buffer.from(JSON.stringify({ returnTo })).toString('base64url');
 
@@ -173,7 +170,6 @@ export class WorkOSAuthStrategy implements AuthStrategy {
         state,
         organizationId,
         screenHint: screenHint as 'sign-up' | 'sign-in' | undefined,
-        prompt,
       });
 
       res.redirect(authorizationUrl);
@@ -325,7 +321,7 @@ export class WorkOSAuthStrategy implements AuthStrategy {
     ${user.organizationName ? `<label>Organisation</label><div class="value">${escapeHtml(user.organizationName)}</div>` : ''}
     <p class="hint">Your account is managed by your organisation via WorkOS.</p>
     <div class="actions">
-      <a href="/auth/login?prompt=select_organization&return_to=%2F" class="btn btn-secondary">Switch Organisation</a>
+      <a href="/auth/logout" class="btn btn-secondary">Switch Organisation</a>
       <a href="/auth/logout" class="btn btn-secondary">Sign out</a>
     </div>
     <div class="footer"><a href="/">&larr; Back</a></div>

--- a/server/bug-reporting.ts
+++ b/server/bug-reporting.ts
@@ -796,7 +796,7 @@ export function getBugReportSpec(): Record<string, unknown> {
             message: 'PUT /api/documents/example-slug/title returned 500',
             data: {
               method: 'PUT',
-              url: 'http://127.0.0.1:3000/api/documents/example-slug/title',
+              url: 'http://127.0.0.1:5556/api/documents/example-slug/title',
               status: 500,
               statusText: 'Internal Server Error',
               requestId: 'example-request-id',

--- a/server/canonical-document.ts
+++ b/server/canonical-document.ts
@@ -886,6 +886,26 @@ export async function mutateCanonicalDocument(args: CanonicalMutationArgs): Prom
       retryWithState: `/api/agent/${args.slug}/state`,
     };
   }
+
+  // Defense-in-depth: when baseRevision is used with a live session, verify
+  // the live authoritative state matches the persisted DB row. baseRevision
+  // validates only the DB revision counter, but the live Yjs doc may contain
+  // unpersisted browser edits — applying against the wrong baseline causes a
+  // split-brain that leaves the projection stuck in yjs_fallback permanently.
+  if (!baseToken && typeof args.baseRevision === 'number' && liveRequired && initialBaseResolution.ok) {
+    const liveMarkdown = stripEphemeralCollabSpans(initialBaseResolution.base.markdown);
+    const persistedMarkdown = stripEphemeralCollabSpans(doc.markdown ?? '');
+    if (liveMarkdown !== persistedMarkdown) {
+      return {
+        ok: false,
+        status: 409,
+        code: 'LIVE_STATE_DIVERGED',
+        error: 'Live document state has diverged from persisted revision; use baseToken instead of baseRevision when collab clients are connected',
+        retryWithState: `/api/agent/${args.slug}/state`,
+      };
+    }
+  }
+
   let handle = await loadCanonicalYDoc(args.slug, { liveRequired });
   if (!handle && liveRequired && hostedRuntime) {
     collabClientBreakdown = await waitForHostedLiveLeaseMaterialization(args.slug);

--- a/server/collab.ts
+++ b/server/collab.ts
@@ -762,7 +762,7 @@ const DEFAULT_INTEGRITY_WARNING_LOG_COOLDOWN_MS = 60 * 1000;
 const DEFAULT_INTEGRITY_WARNING_BLOCK_EXPLOSION = 256;
 const DEFAULT_INTEGRITY_WARNING_REPEAT_BLOCK_THRESHOLD = 64;
 const DEFAULT_INTEGRITY_WARNING_REPEAT_HEADING_THRESHOLD = 3;
-const DEFAULT_PROJECTION_REPAIR_RETRY_SCHEDULE_MS = [0, 500, 2_000];
+const DEFAULT_PROJECTION_REPAIR_RETRY_SCHEDULE_MS = [0, 500, 2_000, 5_000, 15_000, 45_000];
 const DEFAULT_PROJECTION_REPAIR_WORKER_ENABLED = true;
 const DEFAULT_PROJECTION_REPAIR_WORKER_DELAY_MS = 45_000;
 const DEFAULT_PROJECTION_REPAIR_WORKER_INTERVAL_MS = 120_000;
@@ -5191,8 +5191,14 @@ async function runQueuedProjectionRepair(slug: string): Promise<void> {
     const currentIndex = projectionRepairRetryIndex.get(slug) ?? 0;
     const nextIndex = currentIndex + 1;
     if (nextIndex >= schedule.length) {
-      console.error('[collab] projection repair exhausted retries', { slug, reasons, retries: schedule.length });
-      clearProjectionRepairState(slug);
+      console.error('[collab] projection repair exhausted retries; deferring to background worker', { slug, reasons, retries: schedule.length });
+      // Clear scheduling state but preserve reasons so the background
+      // worker can pick up this slug on its next scan cycle instead of
+      // abandoning it permanently.
+      const timer = projectionRepairScheduled.get(slug);
+      if (timer) clearTimeout(timer);
+      projectionRepairScheduled.delete(slug);
+      projectionRepairRetryIndex.delete(slug);
       return;
     }
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -3746,6 +3746,18 @@ export function updateLocalUserName(id: number, name: string | null): boolean {
   return result.changes > 0;
 }
 
+export function updateLocalUserEmail(id: number, email: string): boolean {
+  assertWritesAllowed('updateLocalUserEmail');
+  const result = getDb().prepare('UPDATE local_users SET email = ? WHERE id = ?').run(email, id);
+  return result.changes > 0;
+}
+
+export function updateLocalUserPassword(id: number, passwordHash: string): boolean {
+  assertWritesAllowed('updateLocalUserPassword');
+  const result = getDb().prepare('UPDATE local_users SET password_hash = ? WHERE id = ?').run(passwordHash, id);
+  return result.changes > 0;
+}
+
 // ── User Document Visits (dashboard) ──────────────────────────────────────────
 
 export function upsertUserDocumentVisit(everyUserId: number, slug: string, role?: string): void {

--- a/server/db.ts
+++ b/server/db.ts
@@ -461,6 +461,14 @@ export interface ShareAuthSessionRow {
   updated_at: string;
 }
 
+export interface LocalUserRow {
+  id: number;
+  email: string;
+  password_hash: string;
+  name: string | null;
+  created_at: string;
+}
+
 export interface ActiveCollabConnectionRow {
   connection_id: string;
   document_slug: string;
@@ -1335,6 +1343,17 @@ function initDatabase(): void {
     )
   `);
   d.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_library_documents_slug ON library_documents(document_slug)');
+
+  d.exec(`
+    CREATE TABLE IF NOT EXISTS local_users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL COLLATE NOCASE,
+      password_hash TEXT NOT NULL,
+      name TEXT,
+      created_at TEXT NOT NULL
+    )
+  `);
+  d.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_local_users_email ON local_users(email COLLATE NOCASE)');
 }
 
 export function createDocument(
@@ -3693,6 +3712,27 @@ export function revokeShareAuthSession(sessionToken: string): boolean {
     WHERE session_token_hash = ?
   `).run(now, now, hash);
   return result.changes > 0;
+}
+
+// ── Local Users ──────────────────────────────────────────────────────────────
+
+export function createLocalUser(input: {
+  email: string;
+  passwordHash: string;
+  name: string | null;
+}): LocalUserRow {
+  assertWritesAllowed('createLocalUser');
+  const now = new Date().toISOString();
+  const result = getDb().prepare(`
+    INSERT INTO local_users (email, password_hash, name, created_at)
+    VALUES (?, ?, ?, ?)
+  `).run(input.email, input.passwordHash, input.name, now);
+  return getDb().prepare('SELECT * FROM local_users WHERE id = ?').get(result.lastInsertRowid) as LocalUserRow;
+}
+
+export function getLocalUserByEmail(email: string): LocalUserRow | null {
+  const row = getDb().prepare('SELECT * FROM local_users WHERE email = ? COLLATE NOCASE').get(email) as LocalUserRow | undefined;
+  return row ?? null;
 }
 
 // ── User Document Visits (dashboard) ──────────────────────────────────────────

--- a/server/db.ts
+++ b/server/db.ts
@@ -3735,6 +3735,17 @@ export function getLocalUserByEmail(email: string): LocalUserRow | null {
   return row ?? null;
 }
 
+export function getLocalUserById(id: number): LocalUserRow | null {
+  const row = getDb().prepare('SELECT * FROM local_users WHERE id = ?').get(id) as LocalUserRow | undefined;
+  return row ?? null;
+}
+
+export function updateLocalUserName(id: number, name: string | null): boolean {
+  assertWritesAllowed('updateLocalUserName');
+  const result = getDb().prepare('UPDATE local_users SET name = ? WHERE id = ?').run(name, id);
+  return result.changes > 0;
+}
+
 // ── User Document Visits (dashboard) ──────────────────────────────────────────
 
 export function upsertUserDocumentVisit(everyUserId: number, slug: string, role?: string): void {

--- a/server/home-routes.ts
+++ b/server/home-routes.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { Router, type Request, type Response } from 'express';
+import { fileURLToPath } from 'url';
+import { generateSlug } from './slug.js';
+import { createDocument, createDocumentAccessToken, addEvent } from './db.js';
+import { refreshSnapshotForSlug } from './snapshot.js';
+import { canonicalizeStoredMarks } from '../src/formats/marks.js';
+import { buildShareLink, withShareToken } from './routes.js';
+import { buildProofSdkDocumentPaths, buildProofSdkLinks } from './proof-sdk-routes.js';
+import { captureDocumentCreatedTelemetry } from './telemetry.js';
+import { AGENT_TAB_UI_SCRIPT } from './homepage-script.js';
+import { getPublicBaseUrl } from './public-base-url.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const homeRoutes = Router();
+
+// ---------------------------------------------------------------------------
+// GET / — Serve the rich home page
+// ---------------------------------------------------------------------------
+
+let homeHtmlTemplate: string | null = null;
+
+function getHomeHtmlTemplate(): string {
+  if (homeHtmlTemplate && process.env.NODE_ENV === 'production') return homeHtmlTemplate;
+  const raw = readFileSync(path.join(__dirname, 'resources', 'home.html'), 'utf-8');
+  homeHtmlTemplate = raw.replace('__AGENT_TAB_UI_SCRIPT__', AGENT_TAB_UI_SCRIPT);
+  return homeHtmlTemplate;
+}
+
+function escapeHtmlAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function resolveBaseUrl(req: Request): string {
+  const fromEnv = getPublicBaseUrl(req);
+  if (fromEnv) return fromEnv;
+  const host = req.get('host');
+  if (!host) return `http://localhost:${process.env.PORT || '5555'}`;
+  // Reject hosts that contain characters unsafe for URL/HTML interpolation.
+  if (/[<>"'`]/.test(host)) return `http://localhost:${process.env.PORT || '5555'}`;
+  return `${req.protocol}://${host}`;
+}
+
+homeRoutes.get('/', (req: Request, res: Response) => {
+  const baseUrl = escapeHtmlAttr(resolveBaseUrl(req));
+  const html = getHomeHtmlTemplate().replace(/__PROOF_BASE_URL__/g, baseUrl);
+  res.type('html').send(html);
+});
+
+// ---------------------------------------------------------------------------
+// GET /get-started — Create a blank document and redirect to the editor
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STARTER_MARKDOWN = `# Untitled
+
+`;
+
+homeRoutes.post('/get-started', (req: Request, res: Response) => {
+  const slug = generateSlug();
+  const ownerSecret = randomUUID();
+  const markdown = DEFAULT_STARTER_MARKDOWN;
+  const marks = canonicalizeStoredMarks({});
+  const title = 'Untitled';
+
+  const doc = createDocument(slug, markdown, marks, title, undefined, ownerSecret);
+  const access = createDocumentAccessToken(slug, 'editor');
+  const links = buildShareLink(req, doc.slug);
+  refreshSnapshotForSlug(slug);
+
+  addEvent(slug, 'document.created', {
+    title,
+    shareState: doc.share_state,
+    source: 'get-started',
+    accessRole: access.role,
+  }, 'web:get-started');
+
+  captureDocumentCreatedTelemetry({
+    slug: doc.slug,
+    source: 'get-started',
+    ownerId: undefined,
+    title,
+    shareState: doc.share_state,
+    accessRole: access.role,
+    authMode: 'none',
+    authenticated: false,
+    contentChars: markdown.length,
+  });
+
+  const tokenUrl = withShareToken(links.url, access.secret);
+  res.redirect(302, `${tokenUrl}&welcome=1`);
+});
+
+// ---------------------------------------------------------------------------
+// GET /new — Alias for /get-started
+// ---------------------------------------------------------------------------
+
+homeRoutes.post('/new', (req: Request, res: Response) => {
+  res.redirect(307, '/get-started');
+});

--- a/server/hosted-auth.ts
+++ b/server/hosted-auth.ts
@@ -1,3 +1,5 @@
+import { revokeShareAuthSession } from './db.js';
+
 export type ShareMarkdownAuthMode = 'none' | 'api_key' | 'oauth' | 'oauth_or_api_key' | 'auto';
 
 type PendingAuthStatus = 'pending' | 'completed' | 'failed';
@@ -95,6 +97,6 @@ export async function validateHostedSessionToken(
   };
 }
 
-export function revokeHostedSessionToken(_sessionToken: string): boolean {
-  return false;
+export function revokeHostedSessionToken(sessionToken: string): boolean {
+  return revokeShareAuthSession(sessionToken);
 }

--- a/server/hosted-auth.ts
+++ b/server/hosted-auth.ts
@@ -3,7 +3,8 @@ export type ShareMarkdownAuthMode = 'none' | 'api_key' | 'oauth' | 'oauth_or_api
 type PendingAuthStatus = 'pending' | 'completed' | 'failed';
 
 export function isOAuthConfigured(_publicBaseUrl?: string): boolean {
-  return false;
+  const strategy = (process.env.PROOF_AUTH_STRATEGY || 'none').trim().toLowerCase();
+  return strategy !== 'none';
 }
 
 export function resolveShareMarkdownAuthMode(_publicBaseUrl?: string): Exclude<ShareMarkdownAuthMode, 'auto'> {
@@ -63,7 +64,7 @@ export async function handleOAuthCallback(_input: {
 }
 
 export async function validateHostedSessionToken(
-  _sessionToken: string,
+  sessionToken: string,
   _publicBaseUrl?: string,
 ): Promise<{
   ok: boolean;
@@ -75,9 +76,22 @@ export async function validateHostedSessionToken(
   };
   reason?: string;
 }> {
+  const { getShareAuthSession } = await import('./db.js');
+  const session = getShareAuthSession(sessionToken);
+  if (!session || session.revoked_at) {
+    return { ok: false, reason: 'invalid_session' };
+  }
+  if (new Date(session.session_expires_at) < new Date()) {
+    return { ok: false, reason: 'session_expired' };
+  }
   return {
-    ok: false,
-    reason: 'unsupported',
+    ok: true,
+    principal: {
+      userId: session.every_user_id,
+      email: session.email,
+      name: session.name,
+      sessionToken,
+    },
   };
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,15 +16,18 @@ import {
   enforceBridgeClientCompatibility,
 } from './client-capabilities.js';
 import { getBuildInfo } from './build-info.js';
+import { homeRoutes } from './home-routes.js';
+import { isShuttingDown, setShuttingDown } from './shutdown-state.js';
+import { flushAllDocumentsForShutdown } from './collab.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const PORT = Number.parseInt(process.env.PORT || '4000', 10);
+const PORT = Number.parseInt(process.env.PORT || '5555', 10);
 const DEFAULT_ALLOWED_CORS_ORIGINS = [
-  'http://localhost:3000',
-  'http://127.0.0.1:3000',
-  'http://localhost:4000',
-  'http://127.0.0.1:4000',
+  'http://localhost:5556',
+  'http://127.0.0.1:5556',
+  'http://localhost:5555',
+  'http://127.0.0.1:5555',
   'null',
 ];
 
@@ -46,7 +49,6 @@ async function main(): Promise<void> {
   const allowedCorsOrigins = parseAllowedCorsOrigins();
 
   app.use(express.json({ limit: '10mb' }));
-  app.use(express.static(path.join(__dirname, '..', 'public')));
 
   app.use((req, res, next) => {
     const originHeader = req.header('origin');
@@ -80,31 +82,12 @@ async function main(): Promise<void> {
     next();
   });
 
-  app.get('/', (_req, res) => {
-    res.type('html').send(`<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Proof SDK</title>
-    <style>
-      body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 48px 24px; color: #17261d; background: #f7faf5; }
-      main { max-width: 760px; margin: 0 auto; }
-      h1 { font-size: 2.5rem; margin: 0 0 0.5rem; }
-      p { font-size: 1.05rem; line-height: 1.6; }
-      code { background: #eaf2e6; padding: 0.2rem 0.35rem; border-radius: 4px; }
-      a { color: #266854; }
-    </style>
-  </head>
-  <body>
-    <main>
-      <h1>Proof SDK</h1>
-      <p>Open-source collaborative markdown editing with provenance tracking and an agent HTTP bridge.</p>
-      <p>Start with <code>POST /documents</code>, inspect <a href="/agent-docs">agent docs</a>, or read <a href="/.well-known/agent.json">discovery metadata</a>.</p>
-    </main>
-  </body>
-</html>`);
-  });
+  // Home routes before static middleware so / serves the landing page,
+  // not the SPA index.html that the build copies into public/.
+  app.use(homeRoutes);
+
+  app.use(express.static(path.join(__dirname, '..', 'public'), { index: false }));
+  app.use(express.static(path.join(__dirname, '..', 'dist'), { index: false }));
 
   app.get('/health', (_req, res) => {
     const buildInfo = getBuildInfo();
@@ -131,9 +114,35 @@ async function main(): Promise<void> {
   setupWebSocket(wss);
   await startCollabRuntimeEmbedded(PORT);
 
-  server.listen(PORT, () => {
-    console.log(`[proof-sdk] listening on http://127.0.0.1:${PORT}`);
+  const HOST = process.env.HOST || '0.0.0.0';
+  server.listen(PORT, HOST, () => {
+    console.log(`[proof-sdk] listening on http://${HOST}:${PORT}`);
   });
+
+  // Graceful shutdown: drain HTTP connections, flush collab documents, then exit.
+  const shutdown = async (signal: string) => {
+    if (isShuttingDown()) return;
+    setShuttingDown();
+    console.log(`[proof-sdk] ${signal} received, shutting down…`);
+
+    const forceTimeout = setTimeout(() => {
+      console.error('[proof-sdk] shutdown timeout, forcing exit');
+      process.exit(1);
+    }, 10_000);
+    forceTimeout.unref();
+
+    let exitCode = 0;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    try {
+      await flushAllDocumentsForShutdown();
+    } catch (error) {
+      console.error('[proof-sdk] error during shutdown flush', error);
+      exitCode = 1;
+    }
+    process.exit(exitCode);
+  };
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
 }
 
 main().catch((error) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,8 @@ import { getBuildInfo } from './build-info.js';
 import { homeRoutes } from './home-routes.js';
 import { isShuttingDown, setShuttingDown } from './shutdown-state.js';
 import { flushAllDocumentsForShutdown } from './collab.js';
+import { getAuthStrategy } from './auth/index.js';
+import { createAuthMiddleware } from './auth/middleware.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -81,6 +83,12 @@ async function main(): Promise<void> {
     }
     next();
   });
+
+  // Auth: mount strategy routes (login/callback/logout) and middleware.
+  // Strategy is selected by PROOF_AUTH_STRATEGY env var ('none' or 'workos').
+  const authStrategy = getAuthStrategy();
+  app.use(authStrategy.router);
+  app.use(createAuthMiddleware(authStrategy));
 
   // Home routes before static middleware so / serves the landing page,
   // not the SPA index.html that the build copies into public/.

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,7 @@ import { isShuttingDown, setShuttingDown } from './shutdown-state.js';
 import { flushAllDocumentsForShutdown } from './collab.js';
 import { getAuthStrategy } from './auth/index.js';
 import { createAuthMiddleware } from './auth/middleware.js';
+import { createUserInjectMiddleware } from './auth/user-inject.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -89,6 +90,7 @@ async function main(): Promise<void> {
   const authStrategy = getAuthStrategy();
   app.use(authStrategy.router);
   app.use(createAuthMiddleware(authStrategy));
+  app.use(createUserInjectMiddleware());
 
   // Home routes before static middleware so / serves the landing page,
   // not the SPA index.html that the build copies into public/.

--- a/server/resources/home.html
+++ b/server/resources/home.html
@@ -714,7 +714,7 @@
         </div>
         <div class="logo-proof-animation" aria-hidden="true"></div>
       </div>
-      <a href="/get-started" class="btn-primary mobile-btn">Get started</a>
+      <form action="/get-started" method="post" style="display:inline"><button type="submit" class="btn-primary mobile-btn">Get started</button></form>
     </div>
 
     <div class="logo-proof" data-logo-animation="/assets/proof-logo-animation-v2.lottie?v=20260310c">
@@ -731,7 +731,7 @@
       </div>
     </div>
     
-    <a href="/get-started" class="btn-primary">Get started</a>
+    <form action="/get-started" method="post" style="display:inline"><button type="submit" class="btn-primary">Get started</button></form>
   </div>
   
   <div class="showcase">
@@ -768,7 +768,7 @@
         <h2 class="ca-heading">Connect your agent</h2>
         <p class="ca-subheading">Use Proof in your browser — no install needed.</p>
       </div>
-      <a href="/get-started" class="btn-primary" style="width: max-content;">Get started</a>
+      <form action="/get-started" method="post" style="display:inline"><button type="submit" class="btn-primary" style="width: max-content;">Get started</button></form>
       
       <p class="ca-footer-text">
         No app install needed. The by field powers provenance tracking — the human sees exactly what your agent wrote.<br>
@@ -799,7 +799,7 @@
             <button class="copy-btn" onclick="copyCode('code-any-agent')">Copy</button>
 <pre># Quick start: click "Get started" above, then paste the doc URL into your agent.
 
-export PROOF_BASE_URL="${PROOF_BASE_URL:-http://localhost:4000}"
+export PROOF_BASE_URL="${PROOF_BASE_URL:-__PROOF_BASE_URL__}"
 
 # Optional: install the Proof skill (if your agent supports skills)
 # Skill URL: $PROOF_BASE_URL/proof.SKILL.md
@@ -836,7 +836,7 @@ curl -sS -X POST "$PROOF_BASE_URL/documents/&lt;slug&gt;/ops" \
         <div id="tab-claude-code" class="panel-content">
           <div id="code-claude-code" class="code-shell">
             <button class="copy-btn" onclick="copyCode('code-claude-code')">Copy</button>
-<pre>Read http://localhost:4000/agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration. Ask me before making config changes.</pre>
+<pre>Read __PROOF_BASE_URL__/agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration. Ask me before making config changes.</pre>
           </div>
         <div class="ca-footer-text" style="margin-top: 10px;">Installs the Proof skill, sets up collaboration instructions, and keeps the hosted Proof and Proof SDK workflows aligned.</div>
         </div>
@@ -844,7 +844,7 @@ curl -sS -X POST "$PROOF_BASE_URL/documents/&lt;slug&gt;/ops" \
         <div id="tab-codex" class="panel-content">
           <div id="code-codex" class="code-shell">
             <button class="copy-btn" onclick="copyCode('code-codex')">Copy</button>
-<pre>Read http://localhost:4000/codex-agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration, including Proof SDK-style document creation via POST /documents. Ask me before making config changes.</pre>
+<pre>Read __PROOF_BASE_URL__/codex-agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration, including Proof SDK-style document creation via POST /documents. Ask me before making config changes.</pre>
           </div>
         <div class="ca-footer-text" style="margin-top: 10px;">Installs the Proof skill and saves collaboration instructions to ~/.codex/AGENTS.md, including the neutral `/documents` and `/documents/:slug/bridge/*` workflow.</div>
         </div>
@@ -852,7 +852,7 @@ curl -sS -X POST "$PROOF_BASE_URL/documents/&lt;slug&gt;/ops" \
         <div id="tab-cursor" class="panel-content">
           <div id="code-cursor" class="code-shell">
             <button class="copy-btn" onclick="copyCode('code-cursor')">Copy</button>
-<pre>Read http://localhost:4000/agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration. Ask me before making config changes.</pre>
+<pre>Read __PROOF_BASE_URL__/agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration. Ask me before making config changes.</pre>
           </div>
         <div class="ca-footer-text" style="margin-top: 10px;">Installs the Proof skill, sets up collaboration rules, and points you at the hosted Proof plus reusable Proof SDK routes.</div>
         </div>
@@ -860,7 +860,7 @@ curl -sS -X POST "$PROOF_BASE_URL/documents/&lt;slug&gt;/ops" \
         <div id="tab-windsurf" class="panel-content">
           <div id="code-windsurf" class="code-shell">
             <button class="copy-btn" onclick="copyCode('code-windsurf')">Copy</button>
-<pre>Read http://localhost:4000/agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration. Ask me before making config changes.</pre>
+<pre>Read __PROOF_BASE_URL__/agent-setup and follow all the instructions to install the Proof skill and configure yourself for persistent collaboration. Ask me before making config changes.</pre>
           </div>
         <div class="ca-footer-text" style="margin-top: 10px;">Installs the Proof skill and sets up collaboration rules so Cascade can use the hosted product or the reusable Proof SDK bridge routes.</div>
         </div>
@@ -870,7 +870,7 @@ curl -sS -X POST "$PROOF_BASE_URL/documents/&lt;slug&gt;/ops" \
 
   <div class="bottom-cta">
     <h2>Ready to try it?</h2>
-    <a href="/get-started" class="btn-primary">Get started</a>
+    <form action="/get-started" method="post" style="display:inline"><button type="submit" class="btn-primary">Get started</button></form>
     <p class="ca-footer-text" style="margin-top: 18px;">Hosted Proof is available at <a href="https://proofeditor.ai">proofeditor.ai</a>.</p>
   </div>
 </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -622,7 +622,7 @@ function resolveRequestScopedCollabWsBase(req: Request): string {
   }
 }
 
-function buildShareLink(req: Request, slug: string): { url: string; shareUrl: string } {
+export function buildShareLink(req: Request, slug: string): { url: string; shareUrl: string } {
   const url = `/d/${slug}`;
   const base = getPublicBaseUrl(req);
   return {
@@ -631,7 +631,7 @@ function buildShareLink(req: Request, slug: string): { url: string; shareUrl: st
   };
 }
 
-function withShareToken(url: string, token: string): string {
+export function withShareToken(url: string, token: string): string {
   const separator = url.includes('?') ? '&' : '?';
   return `${url}${separator}token=${encodeURIComponent(token)}`;
 }

--- a/server/share-preview.ts
+++ b/server/share-preview.ts
@@ -10,7 +10,7 @@ const __dirname = path.dirname(__filename);
 
 const OG_IMAGE_WIDTH = 1200;
 const OG_IMAGE_HEIGHT = 630;
-const DEFAULT_PUBLIC_ORIGIN = 'http://localhost:4000';
+const DEFAULT_PUBLIC_ORIGIN = 'http://localhost:5555';
 const PROJECT_ROOT = path.resolve(__dirname, '..');
 
 const CARD_BACKGROUND = '#f0eee7';

--- a/src/tests/collab-build-session-version-eviction.test.ts
+++ b/src/tests/collab-build-session-version-eviction.test.ts
@@ -60,7 +60,7 @@ async function run(): Promise<void> {
     const updated = db.updateDocument(slug, markdownB);
     assert(updated, 'Expected external canonical update to persist');
 
-    const session = collab.buildCollabSession(slug, 'editor', { wsUrlBase: 'ws://localhost:4000/ws' });
+    const session = collab.buildCollabSession(slug, 'editor', { wsUrlBase: 'ws://localhost:5555/ws' });
     assert(Boolean(session), 'Expected buildCollabSession to succeed');
     assert(!collab.__unsafeGetLoadedDocForTests(slug), 'Expected buildCollabSession to evict stale loaded doc after persisted version bump');
 

--- a/src/tests/server-routes-and-share.test.ts
+++ b/src/tests/server-routes-and-share.test.ts
@@ -6,7 +6,7 @@
  * - server onboarding/hook routes
  * - route payload validation for share document APIs
  *
- * Run: PORT=4000 npm run test:server-routes-share
+ * Run: PORT=5555 npm run test:server-routes-share
  */
 
 import { readFileSync, unlinkSync } from 'node:fs';
@@ -17,7 +17,7 @@ import express from 'express';
 import * as Y from 'yjs';
 import { buildSharePreviewModel, resolveOgTextLayout } from '../../server/share-preview';
 
-const SHARE_BASE = process.env.SHARE_BASE_URL ?? 'http://localhost:4000';
+const SHARE_BASE = process.env.SHARE_BASE_URL ?? 'http://localhost:5555';
 const CLIENT_HEADERS = {
   'X-Proof-Client-Version': '0.31.0',
   'X-Proof-Client-Build': 'tests',
@@ -481,7 +481,7 @@ async function runServerHookTests(): Promise<void> {
     const body = response.body || '';
     assertIncludes(
       body,
-      'http://localhost:4000/agent-setup',
+      'http://localhost:5555/agent-setup',
       'agent-setup should point at the local SDK setup endpoint',
     );
     assertIncludes(
@@ -513,7 +513,7 @@ async function runServerHookTests(): Promise<void> {
     );
     assertIncludes(
       body,
-      'PROOF_BASE_URL="${PROOF_BASE_URL:-http://localhost:4000}"',
+      'PROOF_BASE_URL="${PROOF_BASE_URL:-http://localhost:5555}"',
       'landing page should include a configurable local Proof SDK base URL',
     );
     assertIncludes(

--- a/src/tests/share-url-detection.test.ts
+++ b/src/tests/share-url-detection.test.ts
@@ -7,7 +7,7 @@ async function run(): Promise<void> {
   try {
     (globalThis as any).window = {
       location: {
-        origin: 'http://localhost:4000',
+        origin: 'http://localhost:5555',
         pathname: '/d/test-slug',
         search: '',
       },

--- a/src/ui/welcome-card.ts
+++ b/src/ui/welcome-card.ts
@@ -12,7 +12,7 @@ function buildDocUrl(): string {
 function buildPrompt(docUrl: string): string {
   return `Here's my Proof document: ${docUrl}
 
-Proof is a collaborative writing editor that tracks who wrote what (human vs AI). You can read the doc, suggest edits, leave comments, and rewrite content via its HTTP API. API docs: http://localhost:4000/agent-docs
+Proof is a collaborative writing editor that tracks who wrote what (human vs AI). You can read the doc, suggest edits, leave comments, and rewrite content via its HTTP API. API docs: ${window.location.origin}/agent-docs
 
 Connect to this document and help me get started. Write something to kick things off - here are some ideas:
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,53 +28,53 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3000,
+    port: 5556,
     strictPort: true,  // Fail if port in use instead of auto-incrementing
     open: false,
     host: 'localhost',
     proxy: {
       '/assets': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/api': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/d': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/new': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/get-started': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/agent-docs': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/open': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/logout': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/proof.SKILL.md': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/snapshots': {
-        target: 'http://localhost:4000',
+        target: 'http://localhost:5555',
         changeOrigin: true,
       },
       '/ws': {
-        target: 'ws://localhost:4000',
+        target: 'ws://localhost:5555',
         ws: true,
       },
     },


### PR DESCRIPTION
## Summary

- Adds a pluggable authentication system via `PROOF_AUTH_STRATEGY` env var with three strategies:
  - **`none`** (default) — no auth, preserves existing behavior, zero overhead
  - **`local`** — email/password with invite-code-gated registration, server-rendered forms, account settings (name/email/password)
  - **`workos`** — WorkOS AuthKit SSO with organization-level access control, org switcher, sealed session logout
- Auth middleware gates browser routes while exempting API/agent/bridge routes (which use their own bearer-token auth)
- Authenticated user info injected into the editor's share banner bar, with standalone fallback tab on non-editor pages
- Auto-sets editor viewer name from auth session to skip the display name prompt
- Styled to match the existing site design language (Switzer font, warm cream palette, green gradient buttons)

## New files

| File | Purpose |
|------|---------|
| `server/auth/strategy.ts` | `AuthStrategy` interface |
| `server/auth/none.ts` | No-op strategy |
| `server/auth/local.ts` | Email/password strategy with forms and account settings |
| `server/auth/workos.ts` | WorkOS AuthKit strategy with org gating and switcher |
| `server/auth/middleware.ts` | Generic auth middleware |
| `server/auth/forbidden-page.ts` | Styled 403 page for wrong-org users |
| `server/auth/index.ts` | Strategy factory |
| `server/auth/user-inject.ts` | Injects user pill into HTML responses |

## Test plan

- [ ] `PROOF_AUTH_STRATEGY=none` (or unset): verify everything works as before — no login prompts, no auth checks
- [ ] `PROOF_AUTH_STRATEGY=local`: register, login, logout, change name/email/password
- [ ] `PROOF_AUTH_STRATEGY=local PROOF_LOCAL_INVITE_CODE=secret`: verify invite code is required to register
- [ ] `PROOF_AUTH_STRATEGY=workos`: login via AuthKit, org gating, forbidden page, org switcher, logout
- [ ] Verify AI agent API routes (bearer token auth) still work with auth enabled
- [ ] Verify WebSocket collab still works when authenticated
- [ ] Docker: `docker compose up --build` with auth env vars

🤖 Generated with [Claude Code](https://claude.ai/code)