### PR TITLE
Fix self-hosted editor: serve dist/ assets and default COLLAB_EMBEDDED_WS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ VITE_ENABLE_TELEMETRY=false
 
 # Optional app version tag for event properties
 VITE_APP_VERSION=dev
+
+# Required for local self-hosted mode: multiplexes WebSocket collab on the
+# main HTTP port instead of port+1.
+COLLAB_EMBEDDED_WS=1

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,6 +47,7 @@ async function main(): Promise<void> {
 
   app.use(express.json({ limit: '10mb' }));
   app.use(express.static(path.join(__dirname, '..', 'public')));
+  app.use(express.static(path.join(__dirname, '..', 'dist')));
 
   app.use((req, res, next) => {
     const originHeader = req.header('origin');


### PR DESCRIPTION
## Summary

Two issues prevent the editor from loading when running the Proof SDK locally:

- **Missing static middleware for `dist/`**: The server reads `dist/index.html` for the SPA shell but never mounts `express.static` for the `dist/` directory, so `assets/editor.js` returns 404 and the editor stays on "Loading editor..."
- **Wrong WebSocket port without `COLLAB_EMBEDDED_WS`**: The `resolveRequestScopedCollabWsBase` function defaults to `port+1` (4001) for loopback hosts, but the embedded collab runtime multiplexes on the main HTTP port (4000). The editor connects, but Yjs never syncs — the document appears empty.

## Changes

- `server/index.ts`: Add `express.static(path.join(__dirname, '..', 'dist'))` so built assets are served
- `.env.example`: Add `COLLAB_EMBEDDED_WS=1` so `cp .env.example .env` gives a working local setup

## Test plan

- [ ] `npm run build && npm run serve` → open `http://localhost:4000/d/<slug>?token=<token>` → editor loads with document content
- [ ] Verify collab-session endpoint returns `ws://localhost:4000/ws` (not 4001)
- [ ] Verify real-time edits sync between browser and agent bridge API