### PR TITLE
fix(serializer): preserve canonical bullet and rule markers on round-trip

### DIFF
--- a/server/milkdown-headless.ts
+++ b/server/milkdown-headless.ts
@@ -116,6 +116,12 @@ function createSerializer(schema: Schema): (doc: ProseMirrorNode) => string {
     .use(remarkGfm)
     .use(remarkFrontmatter, ['yaml'])
     .use(remarkStringify, {
+      // Preserve canonical markdown style on round-trip. Without these, remark-stringify
+      // defaults to `*` for bullets and `***` for thematic breaks, producing cosmetic git
+      // diffs for any source that uses the `-` / `---` convention (which is the dominant
+      // style in CommonMark and GFM ecosystems).
+      bullet: '-',
+      rule: '-',
       handlers: {
         proofMark: proofMarkHandler,
       },

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -1227,6 +1227,10 @@ class ProofEditorImpl implements ProofEditor {
         // Note: remarkProofMarks is now registered via .use(remarkProofMarksPlugin)
         ctx.update(remarkStringifyOptionsCtx, (prev) => ({
           ...prev,
+          // Preserve canonical markdown style on round-trip. See server/milkdown-headless.ts
+          // for the same options applied on the headless serializer path.
+          bullet: '-',
+          rule: '-',
           handlers: {
             ...(prev.handlers ?? {}),
             proofMark: proofMarkHandler,

--- a/src/tests/milkdown-headless-serializer-style-fidelity.test.ts
+++ b/src/tests/milkdown-headless-serializer-style-fidelity.test.ts
@@ -1,0 +1,74 @@
+import { getHeadlessMilkdownParser, serializeMarkdown } from '../../server/milkdown-headless.js';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+async function run(): Promise<void> {
+  const parser = await getHeadlessMilkdownParser();
+
+  // Canonical source: dash bullets, triple-dash thematic breaks. This is the
+  // dominant style in CommonMark/GFM ecosystems (prettier, markdownlint, GitHub).
+  const source = [
+    '# Heading',
+    '',
+    'Paragraph one.',
+    '',
+    '- bullet one',
+    '- bullet two',
+    '- bullet three',
+    '',
+    '---',
+    '',
+    'Paragraph two.',
+    '',
+    '- nested list parent',
+    '  - nested child a',
+    '  - nested child b',
+    '',
+    '---',
+    '',
+    'Paragraph three.',
+    '',
+  ].join('\n');
+
+  const doc = parser.parseMarkdown(source);
+  const out = await serializeMarkdown(doc);
+
+  // Style fidelity: the serializer must emit the same bullet and rule markers
+  // it received. Without remark-stringify { bullet: '-', rule: '-' }, output
+  // drifts to '*' bullets and '***' rules — semantically equivalent CommonMark
+  // but cosmetically destructive for any workflow that round-trips real docs.
+  assert(
+    !out.includes('* bullet'),
+    `Bullet drift: serializer emitted '*' bullets. Output was:\n${out}`,
+  );
+  assert(
+    out.includes('- bullet one') && out.includes('- bullet two') && out.includes('- bullet three'),
+    `Top-level bullets should serialize as '- '. Output was:\n${out}`,
+  );
+  assert(
+    !out.includes('***'),
+    `Thematic break drift: serializer emitted '***' rules. Output was:\n${out}`,
+  );
+  assert(
+    out.includes('\n---\n'),
+    `Thematic breaks should serialize as '---'. Output was:\n${out}`,
+  );
+
+  // Stability: serialize(parse(source)) === serialize(parse(serialize(parse(source))))
+  // (the property the existing roundtrip test checks; verifying we didn't regress it).
+  const reparsed = parser.parseMarkdown(out);
+  const out2 = await serializeMarkdown(reparsed);
+  assert(
+    out === out2,
+    `Serializer is not stable across round-trips. First output:\n${out}\nSecond output:\n${out2}`,
+  );
+
+  console.log('✓ headless Milkdown serializer style fidelity (bullets, thematic breaks)');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The headless and browser markdown serializers both call `remark-stringify` with only a `handlers` option, accepting all defaults. Those defaults emit `*` for bullets and `***` for thematic breaks. Any document whose source uses the `-` / `---` convention — the dominant style in CommonMark and GFM ecosystems (prettier, markdownlint, GitHub) — drifts cosmetically on every parse → serialize cycle.

For HITL workflows where Proof is the review surface and a local markdown file is the source of truth, this means every sync rewrites the canonical style across the entire doc, burying real edits in noise and breaking any CI markdown linter on the post-sync output.

## Change

Two config sites, identical fix:

- `server/milkdown-headless.ts` — passed to `remark-stringify` in `createSerializer()`. This is the path that produces the markdown returned from `GET /api/agent/:slug/state`.
- `src/editor/index.ts` — applied via `remarkStringifyOptionsCtx` on the browser editor, so client-side serialization (e.g., for outgoing edits / snapshots) matches.

```diff
-    .use(remarkStringify, {
+    .use(remarkStringify, {
+      bullet: '-',
+      rule: '-',
       handlers: { proofMark: proofMarkHandler },
     });
```

## Test coverage

- New: `src/tests/milkdown-headless-serializer-style-fidelity.test.ts` asserts that `-` bullets and `---` thematic breaks survive `serialize(parse(source))`, and verifies the existing stability property (`serialize(parse(x)) === serialize(parse(serialize(parse(x))))`) is preserved.
- Existing `milkdown-headless-serializer-roundtrip.test.ts` still passes — no regression in stability.
- Full `npm test` suite (74 tests including share-route, agent presence, comment/suggestion/rewrite ops, rate limiting) passes with zero failures.

## How to verify locally

```bash
npx tsx src/tests/milkdown-headless-serializer-style-fidelity.test.ts
npx tsx src/tests/milkdown-headless-serializer-roundtrip.test.ts
npm test
```

Or end-to-end against a running server:

```bash
npm run serve &
SLUG=$(curl -s -X POST http://localhost:4000/share/markdown \
  -H 'Content-Type: application/json' \
  -d '{"title":"t","markdown":"- a\n- b\n\n---\n\n- c\n"}' | jq -r .slug)
TOKEN=$(curl -s -X POST http://localhost:4000/share/markdown \
  -H 'Content-Type: application/json' \
  -d '{"title":"t","markdown":"- a"}' | jq -r .accessToken)
# Read back — bullets should be '-' not '*', rule should be '---' not '***'.
curl -s "http://localhost:4000/api/agent/$SLUG/state" \
  -H "Authorization: Bearer $TOKEN" | jq -r .markdown
```

I verified this end-to-end on my fork before submitting: canonical `-` / `---` source survived both pure upload→read and upload→`suggestion.add status:"accepted"`→read.

## Known limitation (out of scope, separate PR)

Tight lists round-trip as loose — input `- a\n- b\n` returns as `- a\n\n- b\n`. The mechanism is different: it's the mdast `spread` property on `list` / `listItem` nodes being set during ProseMirror ↔ AST conversion, not a `remark-stringify` option. Fixing it would require touching the Milkdown transformer / schema's `toMarkdown` paths. I think it's worth a separate PR rather than expanding scope here — happy to take a swing at it next if there's interest.

## Why now

I'm building a small Projects-layer skill on top of `ce-proof` for managing collections of Proof docs across multiple repos, and the HITL round-trip dogfood test I ran on a real plan surfaced this drift. The fix is small and clean enough that it felt worth contributing back rather than carrying as a fork patch.