### PR TITLE
fix: serve built editor assets from dist/ directory

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -47,6 +47,7 @@ async function main(): Promise<void> {
 
   app.use(express.json({ limit: '10mb' }));
   app.use(express.static(path.join(__dirname, '..', 'public')));
+  app.use(express.static(path.join(__dirname, '..', 'dist')));
 
   app.use((req, res, next) => {
     const originHeader = req.header('origin');


### PR DESCRIPTION
## Summary

- The server reads `dist/index.html` and injects meta tags to serve the editor for `/d/:slug` routes, but `dist/` was never registered as a static path.
- This caused the browser to receive 404s for `editor.js` and all other built assets, leaving the page stuck on **"Loading editor..."** after `npm run build`.

## Fix

Add a single `express.static` middleware for the `dist/` directory, directly after the existing `public/` one.

## Reproduction

```bash
npm install
npm run build
npm run serve
# open http://localhost:4000/d/<slug> → stuck on "Loading editor..."
```

## Test plan

- [ ] `npm run build && npm run serve`
- [ ] Create a document via `POST /documents`
- [ ] Open the returned URL — editor loads and connects