### PR TITLE
fix: document COLLAB_EMBEDDED_WS=true requirement for local self-hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ VITE_ENABLE_TELEMETRY=false
 
 # Optional app version tag for event properties
 VITE_APP_VERSION=dev
+
+# Required for local self-hosting: tells the server the collab WebSocket runs
+# on the same port as the HTTP server (embedded mode). Without this, the server
+# assumes the collab runtime is on PORT+1 and the editor stays in "connecting".
+COLLAB_EMBEDDED_WS=true

--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ npm run dev
 Start the local server:
 
 ```bash
-npm run serve
+COLLAB_EMBEDDED_WS=true npm run serve
 ```
 
 The default setup serves the editor on `http://localhost:3000` and the API/server on `http://localhost:4000`.
+
+> **Note:** `COLLAB_EMBEDDED_WS=true` is required for local self-hosting. Without it the server assumes the collab WebSocket runs on `PORT+1` (4001 by default) rather than the same port, and the editor will remain stuck in a "connecting" state. See `.env.example`.
 
 ## Core Routes
 


### PR DESCRIPTION
## Summary

- When running on localhost without `COLLAB_EMBEDDED_WS=true`, the server calculates the collab WebSocket URL as `PORT+1` (4001 by default) rather than the actual server port (4000).
- Nothing runs on port 4001, so the editor silently stays in **"connecting"** state indefinitely with no error message surfaced to the user.
- The embedded collab runtime logs `wsUrlBase=ws://localhost:4000/ws` at startup, but the URL served to clients points elsewhere — the mismatch is invisible without inspecting the `/collab-session` API response.

## Root cause

In `server/routes.ts`, `resolveRequestScopedCollabWsBase` defaults to `appPort + 1` for loopback hosts unless `COLLAB_EMBEDDED_WS` is set, because in the hosted deployment the collab runtime runs as a separate process on a different port. For self-hosted local use, the runtime is always embedded and the env var must be set explicitly.

## Fix

- Add `COLLAB_EMBEDDED_WS=true` to `.env.example` with an explanation.
- Update the README quickstart `npm run serve` command to include it.

## Reproduction

```bash
npm install && npm run build
npm run serve   # without COLLAB_EMBEDDED_WS
# create a doc, open it in browser → "connecting" forever
curl http://localhost:4000/documents/<slug>/collab-session | grep collabWsUrl
# → ws://localhost:4001/ws  (wrong port, nothing listening)
```

## Test plan

- [ ] `COLLAB_EMBEDDED_WS=true npm run serve`
- [ ] Confirm `/collab-session` returns `ws://localhost:4000/ws`
- [ ] Open editor — connects and loads document