### PR TITLE
fix(core): resolve TS2308 duplicate exports so @proof/core compiles under TS5

### DIFF
--- a/packages/doc-core/src/index.ts
+++ b/packages/doc-core/src/index.ts
@@ -1,4 +1,36 @@
 export * from '../../../src/formats/marks.js';
-export * from '../../../src/formats/provenance-sidecar.js';
+// Explicit re-export of provenance-sidecar to avoid name collisions with marks.js:
+// marks.js owns the bare createComment, getUnresolvedComments, and CommentReply
+// names in the new marks-based API. The provenance-sidecar versions are still
+// re-exported here under Sidecar-prefixed aliases so legacy sidecar consumers
+// keep a working path.
+export type {
+  AttestationLevel,
+  TextOrigin,
+  ProvenanceSpan,
+  AttentionData,
+  AttentionEventType,
+  AttentionEvent,
+  ProvenanceMetadata,
+  CommentSelector,
+  Comment,
+  ProvenanceData,
+  CommentReply as SidecarCommentReply,
+} from '../../../src/formats/provenance-sidecar.js';
+export {
+  migrateLegacyProvenance,
+  isLegacyFormat,
+  extractEmbeddedProvenance,
+  generateCommentId,
+  generateReplyId,
+  createReply,
+  addComment,
+  addReplyToComment,
+  setCommentResolved,
+  deleteComment,
+  ensureCommentsArray,
+  createComment as createSidecarComment,
+  getUnresolvedComments as getUnresolvedSidecarComments,
+} from '../../../src/formats/provenance-sidecar.js';
 export * from '../../../src/formats/remark-proof-marks.js';
 export * from '../../../src/shared/agent-identity.js';


### PR DESCRIPTION
## Problem

The `@proof/core` barrel (`packages/doc-core/src/index.ts`) re-exports both `src/formats/marks.ts` and `src/formats/provenance-sidecar.ts` with `export *`. Both modules export the same three names: `createComment`, `getUnresolvedComments` and `CommentReply`. The barrel does not compile:

```
packages/doc-core/src/index.ts(2,1): error TS2308: Module '../../../src/formats/marks.js' has already exported a member named 'createComment'. Consider explicitly re-exporting to resolve the ambiguity.
```

The same error repeats for `getUnresolvedComments` and `CommentReply`. So `@proof/core` cannot be imported from a consumer built under modern strict TypeScript.

The runtime is broken too. A conflicting star export is not a resolvable binding, so `import { createComment } from '@proof/core'` fails at link time:

```
SyntaxError: The requested module './packages/doc-core/src/index.js' contains conflicting star exports for name 'createComment'
```

## Fix

Replace the `export *` from `provenance-sidecar` with explicit named re-exports. `marks.ts` keeps the three shared names. The sidecar versions stay reachable as `createSidecarComment`, `getUnresolvedSidecarComments` and `SidecarCommentReply`. Every other sidecar export keeps its bare name.

`marks.ts` owns the shared names because `provenance-sidecar.ts` says so in its own header: "Legacy provenance format ... New documents should use inline PROOF spans and marks metadata only."

## Verification

Measured with tsc 7.0.2 and Node 24.18.0, against `main` at `fb25787`.

| ref | barrel TS2308 | barrel runtime names |
|---|---|---|
| `main` fb25787 | 3 | 71 |
| this PR | 0 | 75 |

No name is dropped. The four added names are `createComment` and `getUnresolvedComments`, which the ambiguity rule excludes from the namespace on `main`, plus the two Sidecar aliases.

## Question for maintainers

I let `marks` win the three colliding names. If you want `provenance-sidecar` to own them instead, say so and I will flip the direction.
