### PR TITLE
Add PROOF_SINGLE_REPLICA mode to avoid false LIVE_DOC_UNAVAILABLE on single-replica self-hosts

### DIFF
--- a/server/agent-edit-v2.ts
+++ b/server/agent-edit-v2.ts
@@ -35,7 +35,7 @@ import {
   summarizeParseError,
   type HeadlessMilkdownParser,
 } from './milkdown-headless.js';
-import { isHostedRewriteEnvironment } from './rewrite-policy.js';
+import { isHostedMultiReplicaRewriteEnvironment } from './rewrite-policy.js';
 import { getActiveCollabClientBreakdown } from './ws.js';
 import { canonicalizeStoredMarks, type StoredMark } from '../src/formats/marks.js';
 import { refreshSnapshotForSlug } from './snapshot.js';
@@ -126,12 +126,14 @@ const COLLAB_WRITE_STABILITY_SAMPLE_MS = parsePositiveInt(process.env.AGENT_EDIT
 
 function getStrictLiveClientCount(slug: string): number {
   const breakdown = getActiveCollabClientBreakdown(slug);
-  return isHostedRewriteEnvironment() ? breakdown.total : breakdown.exactEpochCount;
+  // Single-replica trusts its own connection view; only a genuine multi-replica
+  // fleet counts ghost leases (a live doc that might be held on a sibling node).
+  return isHostedMultiReplicaRewriteEnvironment() ? breakdown.total : breakdown.exactEpochCount;
 }
 
 async function getStrictLiveClientCountWithGrace(slug: string): Promise<number> {
   let breakdown = getActiveCollabClientBreakdown(slug);
-  if (!isHostedRewriteEnvironment()) return breakdown.exactEpochCount;
+  if (!isHostedMultiReplicaRewriteEnvironment()) return breakdown.exactEpochCount;
   if (breakdown.total === 0 || breakdown.exactEpochCount > 0) return breakdown.total;
 
   const timeoutMs = parsePositiveInt(process.env.HOSTED_LIVE_DOC_GRACE_MS, 1500);

--- a/server/canonical-document.ts
+++ b/server/canonical-document.ts
@@ -66,7 +66,7 @@ import {
   summarizeDocumentIntegrity,
 } from './document-integrity.js';
 import { recordProjectionRepair } from './metrics.js';
-import { isHostedRewriteEnvironment } from './rewrite-policy.js';
+import { isHostedRewriteEnvironment, isSingleReplicaDeployment } from './rewrite-policy.js';
 import { refreshSnapshotForSlug } from './snapshot.js';
 import { pauseDocumentAndPropagate } from './share-state.js';
 import { getActiveCollabClientBreakdown, getActiveCollabClientCount } from './ws.js';
@@ -800,17 +800,24 @@ export async function mutateCanonicalDocument(args: CanonicalMutationArgs): Prom
   const collabRuntimeEnabled = getCollabRuntime().enabled;
   let collabClientBreakdown = getActiveCollabClientBreakdown(args.slug);
   const hostedRuntime = isHostedRewriteEnvironment();
+  // Single-replica self-host: there is no sibling node that could hold the live
+  // doc, so a recent lease without a live connection here means "nobody is
+  // connected", not "another replica owns it". Trust this node's own view.
+  const singleReplica = isSingleReplicaDeployment();
   const strictLiveDocRequested = args.strictLiveDoc !== false;
   if (
     strictLiveDocRequested
     && collabRuntimeEnabled
     && hostedRuntime
+    && !singleReplica
     && collabClientBreakdown.total > 0
     && collabClientBreakdown.exactEpochCount === 0
   ) {
     collabClientBreakdown = await waitForHostedLiveLeaseMaterialization(args.slug);
   }
-  let activeCollabClients = collabClientBreakdown.total;
+  let activeCollabClients = singleReplica
+    ? collabClientBreakdown.exactEpochCount
+    : collabClientBreakdown.total;
   if (strictLiveDocRequested && activeCollabClients > 0 && !collabRuntimeEnabled) {
     return {
       ok: false,
@@ -822,6 +829,7 @@ export async function mutateCanonicalDocument(args: CanonicalMutationArgs): Prom
   }
   const hostedRemoteLiveLease = collabRuntimeEnabled
     && hostedRuntime
+    && !singleReplica
     && collabClientBreakdown.total > 0
     && collabClientBreakdown.exactEpochCount === 0;
   if (strictLiveDocRequested && hostedRemoteLiveLease) {

--- a/server/rewrite-policy.ts
+++ b/server/rewrite-policy.ts
@@ -76,6 +76,26 @@ export function isHostedRewriteEnvironment(runtimeEnvironment: string = getRewri
   return runtimeEnvironment === 'production' || runtimeEnvironment === 'staging' || isRailwayHostedRuntime();
 }
 
+// Single-replica self-hosting. The live-doc gate assumes a multi-replica fleet:
+// a recent collab-session lease with no live connection *on this node* is read
+// as "another replica holds the doc live", returning LIVE_DOC_UNAVAILABLE. On a
+// single replica there are no siblings, so that inference is a false positive
+// that blocks all programmatic edits for the lease window after a viewer leaves.
+// When set, callers trust this node's own connection view (exactEpochCount)
+// instead of ghost leases. Auto-on when RAILWAY_REPLICA_ID is absent would be
+// too aggressive (cold starts), so this stays explicit/opt-in.
+export function isSingleReplicaDeployment(): boolean {
+  const raw = (process.env.PROOF_SINGLE_REPLICA || '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+// Multi-replica hosted runtime: hosted AND not explicitly single-replica. Use
+// this for the "another replica may hold the live doc" gating; keep
+// isHostedRewriteEnvironment for genuinely environment-wide policy.
+export function isHostedMultiReplicaRewriteEnvironment(): boolean {
+  return isHostedRewriteEnvironment() && !isSingleReplicaDeployment();
+}
+
 export function evaluateRewriteLiveClientGate(slug: string, body: unknown): RewriteLiveClientGate {
   return evaluateRewriteLiveClientGateWithOptions(slug, body, {});
 }


### PR DESCRIPTION
## Problem

On a **single-replica** self-hosted deployment, all programmatic edits (`/edit/v2`, `rewrite.apply`) get blocked with `LIVE_DOC_UNAVAILABLE` for several minutes after *any* viewer opens a document — even once nobody is connected.

The live-doc mutation gate is designed for a multi-replica fleet. It treats a recent collab-session lease with **no live connection on the current node** as evidence that *another replica* holds the live document:

```
hostedRemoteLiveLease = collabRuntimeEnabled && hostedRuntime
  && breakdown.total > 0            // a recent session lease exists
  && breakdown.exactEpochCount === 0 // ...but not connected here
```

When a viewer disconnects, `exactEpochCount` drops to `0` but the session lease lingers for `COLLAB_SESSION_TTL_SECONDS` (default **300s**). On a single node there is no sibling replica, so `total > 0 && exactEpochCount === 0` simply means "nobody is connected" — yet the gate returns `LIVE_DOC_UNAVAILABLE` and blocks the edit. In practice this pushes agents to **recreate documents** instead of updating in place (which loses comments/marks anchored to the original).

`isHostedRewriteEnvironment()` is true whenever `PROOF_ENV=production`, so any production single-container deployment hits this.

## Fix

Add an opt-in `PROOF_SINGLE_REPLICA` flag. When set, the gate trusts **this node's own** connection view instead of ghost leases.

- `rewrite-policy.ts`: new `isSingleReplicaDeployment()` + derived `isHostedMultiReplicaRewriteEnvironment()`.
- `canonical-document.ts`: `activeCollabClients` derives from `exactEpochCount` (own connections) instead of `total`; the `hostedRemoteLiveLease` block is skipped when single-replica.
- `agent-edit-v2.ts`: `getStrictLiveClientCount` / `…WithGrace` use `exactEpochCount` when single-replica.

**Default behavior is unchanged when the flag is unset** — multi-replica deployments keep the existing conservative gating.

## Result (verified on a single-container deployment)

With `PROOF_SINGLE_REPLICA=1`:
- `/edit/v2` succeeds **while a viewer is actively connected** — the edit merges into the live Yjs document, and the connected browser receives it in real time (`collab.status: confirmed`).
- A human comment added with a viewer present **persists and survives** subsequent agent edits.
- No more `LIVE_DOC_UNAVAILABLE` false positives after a viewer disconnects.

## Notes

- Kept opt-in/explicit rather than auto-detecting (e.g. "no `RAILWAY_REPLICA_ID`"), since cold starts could misclassify; happy to switch to auto-detection if preferred.
- Glad to add documentation (env var reference) and tests wherever you'd like them — didn't want to guess at the preferred location/format.
