### PR TITLE
fix(agent-edit): stop replace from orphaning a closing </span> on wrapped authored spans

### DIFF
--- a/server/proof-span-strip.ts
+++ b/server/proof-span-strip.ts
@@ -429,7 +429,16 @@ export function expandRangeToIncludeFullyWrappedAuthoredSpan(
   let nextEnd = end;
 
   for (const span of listAuthoredProofSpanBounds(markdown)) {
-    if (nextStart === span.contentStart && nextEnd === span.contentEnd) {
+    // Expand when the resolved range covers the span's entire inner content and
+    // sits within the span's outer tag bounds. Anchor resolution that strips
+    // authored spans can return a range that reaches the opening tag on one
+    // side but stops at the content edge on the other (e.g. [openStart,
+    // contentEnd]); requiring exact content-bound equality left the unmatched
+    // tag behind as an orphaned </span>. A partial-content edit does not cover
+    // the full content, so it is left untouched and keeps its wrapper.
+    const coversFullContent = nextStart <= span.contentStart && nextEnd >= span.contentEnd;
+    const withinSpanBounds = nextStart >= span.openStart && nextEnd <= span.closeEnd;
+    if (coversFullContent && withinSpanBounds) {
       nextStart = span.openStart;
       nextEnd = span.closeEnd;
       break;


### PR DESCRIPTION
## Problem

When an agent `replace` operation targets text inside a fully-wrapped authored span, the result can contain an unbalanced closing tag:

```
Input:    Hello <span data-proof="authored" data-by="ai:old">world</span>!
Expected: Hello <span data-proof="authored" data-by="ai:new">earth</span>!
Actual:   Hello <span data-proof="authored" data-by="ai:new">earth</span></span>!   <- orphaned </span>
```

## Cause

`expandRangeToIncludeFullyWrappedAuthoredSpan` only expanded the edit range when it exactly equalled a span's content bounds (`nextStart === contentStart && nextEnd === contentEnd`). When anchor resolution strips authored spans, it can return a range that includes the opening tag but stops at the content edge (`[openStart, contentEnd]`). The exact-equality check then misses, the range covers the opening tag and content but not the closing tag, and the trailing `</span>` is left behind.

## Fix

Expand whenever the resolved range covers the full span content and lies within the span's outer bounds. A partial-content edit does not cover the full content, so it is left untouched and keeps its wrapper.

## Test

`src/tests/edit-ops.test.ts` ("replace fully wrapped authored span replaces stale wrapper instead of nesting it") now passes; full file 17/17. No other edit-ops cases change.
