### PR TITLE
fix(agent): report most-recent session id and status from getAgentStatus

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,5 +1,26 @@
 import { getSessionManager } from './session-manager';
+import type { AgentSessionStatus } from './session-manager';
 import type { AgentStatus, AgentStatusInfo } from './types';
+
+function mapSessionStatusToAgentStatus(status: AgentSessionStatus): AgentStatus {
+  switch (status) {
+    case 'reading':
+    case 'thinking':
+    case 'acting':
+    case 'waiting':
+      return 'running';
+    case 'completed':
+      return 'completed';
+    case 'cancelled':
+      return 'cancelled';
+    case 'error':
+    case 'interrupted':
+      return 'error';
+    case 'idle':
+    default:
+      return 'idle';
+  }
+}
 
 export type AgentSessionSummary = {
   id: string;
@@ -10,9 +31,21 @@ export type AgentSessionSummary = {
 };
 
 export function getAgentStatus(): AgentStatusInfo {
-  const hasActive = getSessionManager().getActiveSessions().length > 0;
-  const status: AgentStatus = hasActive ? 'running' : 'offline';
-  return { status };
+  const sessions = getSessionManager().getAllSessions();
+  if (sessions.length === 0) {
+    return { status: 'offline' };
+  }
+  // Report the most recently active session so callers can identify which
+  // session the status refers to (the AgentStatusInfo.sessionId contract),
+  // rather than collapsing every session into a single running/offline flag.
+  const mostRecent = sessions.reduce((latest, session) => (
+    session.lastActivity.getTime() > latest.lastActivity.getTime() ? session : latest
+  ));
+  return {
+    status: mapSessionStatusToAgentStatus(mostRecent.status),
+    sessionId: mostRecent.id,
+    startedAt: mostRecent.startTime.getTime(),
+  };
 }
 
 export function getAgentSessionsSummary(): AgentSessionSummary[] {


### PR DESCRIPTION
## Problem

`getAgentStatus()` returned only a `running`/`offline` flag and never populated `AgentStatusInfo.sessionId`, even though `sessionId` is a declared field on the type and `getAgentStatus` is exposed as `window.getAgentStatus`. Callers could not tell which session the status referred to, and a completed session reported `offline` rather than `completed`.

## Fix

Report the most-recently-active session (by `lastActivity`): return its `id` as `sessionId`, its `startTime` as `startedAt`, and a mapped status (active states -> `running`; `completed`/`cancelled`/`error` preserved; `interrupted` -> `error`). With no sessions it still returns `offline`.

## Test

`src/tests/agent-status.test.ts` now passes (prefers the most-recent completed session, and the most-recent running session).
