### PR TITLE
fix(collab): skip live-doc registration grace when the direct connection timed out

### DIFF
--- a/server/collab.ts
+++ b/server/collab.ts
@@ -7300,11 +7300,16 @@ export async function loadCanonicalYDoc(
         degradedReason: null,
       };
     }
-    const { doc, cleanup } = await getOrLoadHocuspocusDoc(slug, {
+    const { doc, cleanup, timedOut } = await getOrLoadHocuspocusDoc(slug, {
       allowDirectConnection: options.liveRequired === true,
     });
     let registeredLiveDoc = getLiveHocuspocusDoc(slug);
-    if (!registeredLiveDoc && options.liveRequired) {
+    // Only wait out the registration grace when the direct connection itself did
+    // not time out. A stalled/timed-out direct connection establishes nothing for
+    // the live-doc map to register, so the bounded direct-connection timeout would
+    // otherwise be followed by the full (much longer) registration grace, defeating
+    // its purpose. If the doc is already registered, the check above returns it.
+    if (!registeredLiveDoc && options.liveRequired && !timedOut) {
       registeredLiveDoc = await waitForLiveHocuspocusDocRegistration(slug);
     }
     if (registeredLiveDoc) {
@@ -9560,7 +9565,7 @@ type DirectConnectionLike = {
 async function getOrLoadHocuspocusDoc(
   slug: string,
   options: { allowDirectConnection?: boolean } = {},
-): Promise<{ doc: Y.Doc | null; cleanup?: () => Promise<void> }> {
+): Promise<{ doc: Y.Doc | null; cleanup?: () => Promise<void>; timedOut?: boolean }> {
   const existing = getLiveHocuspocusDoc(slug);
   if (existing) return { doc: existing };
   if (!options.allowDirectConnection) return { doc: null };
@@ -9621,9 +9626,9 @@ async function getOrLoadHocuspocusDoc(
     }
   };
 
-  if (doc && typeof (doc as any).getText === 'function') return { doc, cleanup };
-  if (direct) return { doc: null, cleanup };
-  return { doc: null };
+  if (doc && typeof (doc as any).getText === 'function') return { doc, cleanup, timedOut: directTimedOut };
+  if (direct) return { doc: null, cleanup, timedOut: directTimedOut };
+  return { doc: null, timedOut: directTimedOut };
 }
 
 async function waitForLiveHocuspocusDocRegistration(slug: string): Promise<Y.Doc | null> {


### PR DESCRIPTION
## Problem

`loadCanonicalYDoc({ liveRequired: true })` bounds the `openDirectConnection`
attempt with `COLLAB_DIRECT_CONNECTION_TIMEOUT_MS`, but when that attempt times
out it still waited the full `COLLAB_LIVE_DOC_REGISTRATION_GRACE_MS` (default
1500ms) for a live doc to register. So a stalled direct connection took roughly
`direct-timeout + 1500ms` to return instead of bailing promptly, defeating the
purpose of the bounded direct-connection timeout.

## Fix

A timed-out direct connection establishes nothing for the live-doc map to
register, so there is nothing to wait for. Propagate a `timedOut` flag from
`getOrLoadHocuspocusDoc` and skip the registration grace when the direct
connection timed out. An already-registered live doc is still returned by the
point-in-time check before the grace, so a concurrently present live doc is
unaffected.

## Test

`src/tests/collab-direct-connection-timeout-regression.test.ts` (patches
`openDirectConnection` to stall, sets a 50ms direct timeout, expects the load to
return `null` in under 1000ms) now passes; it previously took ~1570ms.
