### PR TITLE
fix(agent-edit-v2): detect live ref drift against persisted base not live fallback

### DIFF
--- a/server/agent-edit-v2.ts
+++ b/server/agent-edit-v2.ts
@@ -867,7 +867,17 @@ export async function applyAgentEditV2(
   const usingAuthoritativeFallback = authoritativeBase.base.source === 'live_yjs'
     || authoritativeMarkdown !== stripEphemeralCollabSpans(doc.markdown ?? '');
   if (usingAuthoritativeFallback) {
-    const persistedBase = parseMarkdownWithHtmlFallback(parser, stripEphemeralCollabSpans(doc.markdown ?? ''));
+    // The b1..bN refs the agent sent were assigned against the base it declared. For a
+    // baseRevision-only edit that base is the persisted document row at that revision.
+    // doc.markdown here is the live-fallback canonical read, so using it would compare the
+    // live authoritative fragment against itself and never detect that a concurrent edit
+    // shifted block topology under the agent's refs. Use the persisted row as the drift
+    // baseline. When a baseToken is supplied the agent opted into the live base directly
+    // (validated above), so that base is already the correct comparison frame.
+    const driftBaselineMarkdown = baseToken
+      ? stripEphemeralCollabSpans(doc.markdown ?? '')
+      : stripEphemeralCollabSpans(getDocumentBySlug(slug)?.markdown ?? doc.markdown ?? '');
+    const persistedBase = parseMarkdownWithHtmlFallback(parser, driftBaselineMarkdown);
     if (!persistedBase.doc) {
       return {
         status: 500,

--- a/server/agent-edit-v2.ts
+++ b/server/agent-edit-v2.ts
@@ -874,9 +874,14 @@ export async function applyAgentEditV2(
     // shifted block topology under the agent's refs. Use the persisted row as the drift
     // baseline. When a baseToken is supplied the agent opted into the live base directly
     // (validated above), so that base is already the correct comparison frame.
+    const persistedDriftBaseline = baseToken ? null : getDocumentBySlug(slug);
     const driftBaselineMarkdown = baseToken
       ? stripEphemeralCollabSpans(doc.markdown ?? '')
-      : stripEphemeralCollabSpans(getDocumentBySlug(slug)?.markdown ?? doc.markdown ?? '');
+      : stripEphemeralCollabSpans(
+        persistedDriftBaseline?.revision === baseRevision
+          ? persistedDriftBaseline.markdown
+          : doc.markdown ?? '',
+      );
     const persistedBase = parseMarkdownWithHtmlFallback(parser, driftBaselineMarkdown);
     if (!persistedBase.doc) {
       return {


### PR DESCRIPTION
## Problem

`POST /api/agent/:slug/edit/v2` could silently clobber a concurrent human edit and apply an agent's `replace_block` to the wrong block, returning `200 success` instead of rejecting.

Scenario (covered by the existing `agent-edit-v2-live-structural-drift-regression` test):

1. An agent snapshots a document and captures a block ref (e.g. `b3` = "Second paragraph.").
2. A live collaborator inserts a block before that block, so the live fragment shifts ("Second paragraph." moves to `b4`), without bumping the persisted revision.
3. The agent sends `replace_block` on its captured `b3` with `baseRevision` = the snapshot revision.

Expected: `409 FRAGMENT_DIVERGENCE` (the block topology drifted under the agent's ref).
Actual: `200` - the ref resolved positionally to the now-shifted `b3` (the human's new block) and replaced it, discarding the concurrent insert.

## Root cause

The ref-drift guard `findLiveRefDrift(persistedDescriptors, liveDescriptors, ...)` is meant to compare the persisted base (what the agent's refs were captured against) with the live authoritative fragment. But both sides were sourced from the same value:

- `liveDescriptors` come from `authoritativeBase.base.markdown` (the live fragment).
- `persistedDescriptors` come from `doc.markdown`, where `doc = await getCanonicalReadableDocument(slug, 'state') ?? getDocumentBySlug(slug)`.

Under live presence, `getCanonicalReadableDocument(..., 'state')` returns the live (yjs) fallback, so `doc.markdown` is the live fragment too. The guard therefore compared the live fragment against itself and never detected drift - exactly when it is needed.

Instrumented confirmation: with a live client connected, `persistedDescriptors` and `liveDescriptors` were identical (both the 5-block live fragment, including the human insert), while the real persisted row (`getDocumentBySlug`) still held the 4-block base the agent's `b3` was captured against.

## Fix

Source the drift baseline from the real persisted document row for `baseRevision`-only edits (the frame the agent's refs were actually captured against). When a `baseToken` is supplied, the agent explicitly opted into the live authoritative base (already validated above), so that base remains the comparison frame and behavior is unchanged.

```ts
const persistedDriftBaseline = baseToken ? null : getDocumentBySlug(slug);
const driftBaselineMarkdown = baseToken
  ? stripEphemeralCollabSpans(doc.markdown ?? '')
  : stripEphemeralCollabSpans(
    persistedDriftBaseline?.revision === baseRevision
      ? persistedDriftBaseline.markdown
      : doc.markdown ?? '',
  );
const persistedBase = parseMarkdownWithHtmlFallback(parser, driftBaselineMarkdown);
```

The persisted row is used only when its revision still equals the declared `baseRevision`. Otherwise the read falls back to `doc.markdown`.

## Verification

- `src/tests/agent-edit-v2-live-structural-drift-regression.test.ts`: fails on `main` (200), passes with this change (409, the human insert is preserved and the persisted revision is unchanged).
- No new failures across the related agent-edit / edit-v2 regression suites; `baseToken`-based edits are unaffected (no spurious `FRAGMENT_DIVERGENCE`).
- No new type errors (`tsc -p tsconfig.server.json` unchanged).

