### PR TITLE
fix(collab): stop /documents/:slug/ops replaying stale DB markdown into live rooms

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1728,20 +1728,18 @@ apiRoutes.post('/documents/:slug/ops', opsRateLimiter, async (req: Request, res:
 
   if (result.status >= 200 && result.status < 300) {
     // Collab mutations for rewrite.apply are committed through the canonical Yjs path.
-    // Other ops still need explicit projection sync into the live room.
+    // Other (engine-backed) ops only refresh presence/cursor coupling below; they do not
+    // push a DB snapshot into the live room.
     if (op !== 'rewrite.apply') {
       try {
         const collabRuntime = getCollabRuntime();
         if (collabRuntime.enabled) {
           const updatedDoc = getDocumentBySlug(slug);
           if (updatedDoc) {
-            const applyOptions = {
-              markdown: typeof updatedDoc.markdown === 'string' ? updatedDoc.markdown : undefined,
-              marks: parseJson(updatedDoc.marks),
-              source: 'rest-ops',
-            };
-            await applyCanonicalDocumentToCollab(slug, applyOptions);
-
+            // Route-level reapplication from the DB can replay stale markdown over concurrent
+            // live edits that are not yet persisted, so engine-backed (non-rewrite.apply) ops
+            // no longer push a broad DB snapshot into the live room. Only the narrow,
+            // non-content presence/cursor coupling below is synced.
             if (participation) {
               try {
                 applyAgentPresenceToLoadedCollab(slug, participation.presenceEntry, {


### PR DESCRIPTION
## Problem

`POST /documents/:slug/ops` reapplies the persisted DB row into the live collab room after any non-`rewrite.apply` mutation, using `source: 'rest-ops'`:

```ts
const applyOptions = {
  markdown: typeof updatedDoc.markdown === 'string' ? updatedDoc.markdown : undefined,
  marks: parseJson(updatedDoc.marks),
  source: 'rest-ops',
};
await applyCanonicalDocumentToCollab(slug, applyOptions);
```

Unlike every other server-side write source, `rest-ops` is not covered by `shouldBlockLegacyLiveApplySource`, so this reapply is not blocked when a live shared doc is present. A point-in-time DB snapshot can then replay stale markdown over concurrent edits that are not yet persisted.

The repo's own `collab-security` invariant already asserts this reapply should be gone, so that check fails on `main`:

```
Expected /documents/:slug/ops to avoid broad DB reapply after engine-backed mutations
```

## Fix

Engine-backed (non-`rewrite.apply`) ops now only refresh the narrow presence/cursor coupling and no longer push a broad DB snapshot into the live room. `rewrite.apply` continues to commit through the canonical Yjs path, and the trailing `document.updated` broadcast still notifies live clients. This mirrors the pattern the agent routes and bridge already follow (presence/verification sync, no broad reapply).

## Verification

The `collab-security` invariant for this reapply flips from failing to passing:

- before (`main`): `routesSource.includes("source: 'rest-ops'")` is `true`, assertion fails
- after: the `source: 'rest-ops'` reapply is gone and the explanatory comment is present, assertion passes

`tsc --noEmit -p tsconfig.server.json` reports 0 errors before and after (no new type errors). The change is 6 insertions / 8 deletions in one file.

Fixes #63
