### PR TITLE
fix(editor): render visible highlight + popover for Flag marks

### DIFF
--- a/src/editor/plugins/mark-popover.ts
+++ b/src/editor/plugins/mark-popover.ts
@@ -1215,6 +1215,10 @@ class MarkPopoverController {
   }
 
   private renderSuggestion(mark: Mark): void {
+    if (mark.kind === 'flagged') {
+      this.renderFlag(mark);
+      return;
+    }
     this.popover.innerHTML = '';
 
     const header = document.createElement('div');
@@ -1271,6 +1275,45 @@ class MarkPopoverController {
     if (canEdit) {
       actions.appendChild(applyButton);
       actions.appendChild(rejectButton);
+    }
+
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.textContent = 'Close';
+    installTouchSafeButton(closeButton, () => {
+      this.close();
+    });
+    actions.appendChild(closeButton);
+
+    this.popover.appendChild(header);
+    this.popover.appendChild(body);
+    this.popover.appendChild(actions);
+  }
+
+  private renderFlag(mark: Mark): void {
+    this.popover.innerHTML = '';
+
+    const header = document.createElement('div');
+    header.className = 'mark-popover-header';
+    header.textContent = `Flagged by ${getActorName(mark.by)}`;
+
+    const body = document.createElement('div');
+    body.className = 'mark-popover-body';
+    const note = (mark.data as { note?: string } | undefined)?.note;
+    body.textContent = note || mark.quote || '';
+
+    const actions = document.createElement('div');
+    actions.className = 'mark-popover-actions';
+
+    if (canCommentInRuntime()) {
+      const removeButton = document.createElement('button');
+      removeButton.type = 'button';
+      removeButton.textContent = 'Remove flag';
+      installTouchSafeButton(removeButton, () => {
+        deleteMark(this.view, mark.id);
+        this.close();
+      });
+      actions.appendChild(removeButton);
     }
 
     const closeButton = document.createElement('button');

--- a/src/editor/plugins/marks.ts
+++ b/src/editor/plugins/marks.ts
@@ -3110,8 +3110,13 @@ function createDecorations(
     switch (mark.kind) {
       case 'authored':
       case 'approved':
-      case 'flagged':
         continue;
+
+      case 'flagged': {
+        style = STYLES.flagged;
+        cssClass = `mark-flagged ${isActive ? 'mark-active' : ''}`;
+        break;
+      }
 
       case 'comment': {
         const data = mark.data as CommentData;
@@ -3220,6 +3225,15 @@ function injectGlowStyles(): void {
     }
     @keyframes proof-delete-glow {
       0% { box-shadow: 0 0 8px rgba(239, 68, 68, 0.6); }
+      100% { box-shadow: none; }
+    }
+
+    /* Flag glow (dusty rose, box-shadow only so the flag background persists) */
+    .mark-flagged.proof-mark-new {
+      animation-name: proof-flag-glow;
+    }
+    @keyframes proof-flag-glow {
+      0% { box-shadow: 0 0 8px rgba(252, 165, 165, 0.8); }
       100% { box-shadow: none; }
     }
 


### PR DESCRIPTION
## Problem

Flagging a selection via the selection bar creates a `kind: 'flagged'` mark (correctly anchored, saved, and counted by the heatmap gutter) but produces **no visible feedback in the document** — the decoration pass in `createDecorations` explicitly skips flagged marks:

```ts
case 'authored':
case 'approved':
case 'flagged':
    continue;
```

Meanwhile `STYLES.flagged` (the dusty-rose treatment) is defined directly above but never used. From a user's perspective the only observable effect of clicking Flag is the document saving again. Clicking an (invisible) flagged range would also open an empty "Suggestion" popover whose Apply/Reject buttons are no-ops for flagged marks.

## Fix

- **`src/editor/plugins/marks.ts`** — give `'flagged'` its own decoration case (`mark-flagged` class, wired to the existing `STYLES.flagged`: 3px rose left border + pale rose background), plus a flag-specific new-mark glow keyframe (box-shadow only, mirroring delete's). Without the dedicated keyframe, the default green glow's `forwards` fill permanently overrides the rose tint on freshly created flags.
- **`src/editor/plugins/mark-popover.ts`** — add a `renderFlag()` card: "Flagged by {actor}", body shows the flag note (or quoted text), actions are **Remove flag** (via `deleteMark`) and Close — replacing the broken empty suggestion popover.

## Notes

- The rose visual language is upstream's own dormant `STYLES.flagged`, just connected; the popover card follows the existing comment-card pattern.
- `npm run build` clean; test suites pass at parity with baseline on our fork (no new failures). No decoration/DOM-level test harness existed to extend naturally — happy to add one if you can point at a preferred pattern.
- Found while running Proof for real document review; flags created before the fix render correctly after it, since the data layer always worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ro6KiE6zCSSzsqeyVoAu8M